### PR TITLE
Add method to standardize date formatting across the app

### DIFF
--- a/src/main/java/budgetbuddy/commons/util/AppUtil.java
+++ b/src/main/java/budgetbuddy/commons/util/AppUtil.java
@@ -2,6 +2,8 @@ package budgetbuddy.commons.util;
 
 import static java.util.Objects.requireNonNull;
 
+import java.text.SimpleDateFormat;
+
 import budgetbuddy.MainApp;
 import javafx.scene.image.Image;
 
@@ -13,6 +15,16 @@ public class AppUtil {
     public static Image getImage(String imagePath) {
         requireNonNull(imagePath);
         return new Image(MainApp.class.getResourceAsStream(imagePath));
+    }
+
+    /**
+     * Returns a {@code SimpleDateFormat} for use in displaying/parsing dates.
+     * The primary purpose of this method is to standardise date display across the app.
+     */
+    public static SimpleDateFormat getDateFormat() {
+        SimpleDateFormat format = new SimpleDateFormat("d/M/yy");
+        format.setLenient(false);
+        return format;
     }
 
     /**

--- a/src/main/java/budgetbuddy/logic/parser/CommandParserUtil.java
+++ b/src/main/java/budgetbuddy/logic/parser/CommandParserUtil.java
@@ -1,8 +1,8 @@
 package budgetbuddy.logic.parser;
 
+import static budgetbuddy.commons.util.AppUtil.getDateFormat;
 import static java.util.Objects.requireNonNull;
 
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.regex.Matcher;
 
@@ -134,8 +134,7 @@ public class CommandParserUtil {
         requireNonNull(date);
         String trimmedDate = date.trim();
         try {
-            // TODO Some problems, e.g. 12/13/2020 gets parsed to 12/01/2021
-            return new SimpleDateFormat("dd/MM/yy").parse(trimmedDate);
+            return getDateFormat().parse(trimmedDate);
         } catch (java.text.ParseException e) {
             throw new ParseException(e.getMessage());
         }

--- a/src/main/java/budgetbuddy/model/loan/Loan.java
+++ b/src/main/java/budgetbuddy/model/loan/Loan.java
@@ -3,7 +3,6 @@ package budgetbuddy.model.loan;
 import static budgetbuddy.commons.util.AppUtil.getDateFormat;
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Objects;
 

--- a/src/main/java/budgetbuddy/model/loan/Loan.java
+++ b/src/main/java/budgetbuddy/model/loan/Loan.java
@@ -1,5 +1,6 @@
 package budgetbuddy.model.loan;
 
+import static budgetbuddy.commons.util.AppUtil.getDateFormat;
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.text.SimpleDateFormat;
@@ -56,8 +57,7 @@ public class Loan {
     }
 
     public String getDateString() {
-        // TODO Should standardize the date display format throughout the app.
-        return new SimpleDateFormat("dd/MM/yyyy").format(date);
+        return getDateFormat().format(date);
     }
 
     public Description getDescription() {

--- a/src/main/java/budgetbuddy/storage/loans/JsonAdaptedLoan.java
+++ b/src/main/java/budgetbuddy/storage/loans/JsonAdaptedLoan.java
@@ -1,7 +1,9 @@
 package budgetbuddy.storage.loans;
 
+import static budgetbuddy.commons.util.AppUtil.getDateFormat;
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.text.ParseException;
 import java.util.Date;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -116,7 +118,12 @@ public class JsonAdaptedLoan {
      * @throws IllegalValueException If adapted object cannot be converted.
      */
     private Date checkDate() throws IllegalValueException {
-        // TODO Check validity of date.
+        try {
+            String dateStr = getDateFormat().format(date);
+            getDateFormat().parse(dateStr);
+        } catch (ParseException e) {
+            throw new IllegalValueException("Error reading stored date.");
+        }
         return date;
     }
 

--- a/src/main/java/budgetbuddy/storage/loans/JsonAdaptedLoan.java
+++ b/src/main/java/budgetbuddy/storage/loans/JsonAdaptedLoan.java
@@ -67,16 +67,17 @@ public class JsonAdaptedLoan {
      * @throws IllegalValueException If any data constraints were violated in the adapted loan.
      */
     public Loan toModelType() throws IllegalValueException {
-        Person person = new Person(checkName());
-        return new Loan(person, checkDirection(), checkAmount(),
-                checkDate(), checkDescription(), checkStatus());
+        Person person = new Person(getValidatedName());
+        return new Loan(person, getValidatedDirection(), getValidatedAmount(),
+                getValidatedDate(), getValidatedDescription(), getValidatedStatus());
     }
 
     /**
-     * Checks that adapted name can be converted into model's {@code Name} object.
-     * @throws IllegalValueException If adapted object cannot be converted.
+     * Validates and converts the adapted name into the model's {@code Name} object.
+     * @return The validated and converted name.
+     * @throws IllegalValueException If validation fails.
      */
-    private Name checkName() throws IllegalValueException {
+    private Name getValidatedName() throws IllegalValueException {
         if (personName == null) {
             throw new IllegalValueException(
                     String.format(MISSING_FIELD_MESSAGE_FORMAT, Person.class.getSimpleName()));
@@ -88,10 +89,11 @@ public class JsonAdaptedLoan {
     }
 
     /**
-     * Checks that adapted direction can be converted into model's {@code Direction} object.
-     * @throws IllegalValueException If adapted object cannot be converted.
+     * Validates and converts the adapted direction into the model's {@code Direction} object.
+     * @return The validated and converted direction.
+     * @throws IllegalValueException If validation fails.
      */
-    private Direction checkDirection() throws IllegalValueException {
+    private Direction getValidatedDirection() throws IllegalValueException {
         if (direction == null) {
             throw new IllegalValueException(
                     String.format(MISSING_FIELD_MESSAGE_FORMAT, Direction.class.getSimpleName()));
@@ -103,10 +105,11 @@ public class JsonAdaptedLoan {
     }
 
     /**
-     * Checks that adapted amount can be converted into model's {@code Amount} object.
-     * @throws IllegalValueException If adapted object cannot be converted.
+     * Validates and converts the adapted amount into the model's {@code Amount} object.
+     * @return The validated and converted amount.
+     * @throws IllegalValueException If validation fails.
      */
-    private Amount checkAmount() throws IllegalValueException {
+    private Amount getValidatedAmount() throws IllegalValueException {
         if (!Amount.isValidAmount(amount)) {
             throw new IllegalValueException(Amount.MESSAGE_CONSTRAINTS);
         }
@@ -114,10 +117,11 @@ public class JsonAdaptedLoan {
     }
 
     /**
-     * Checks that adapted date can be converted into model's {@code Date} object.
-     * @throws IllegalValueException If adapted object cannot be converted.
+     * Validates the adapted date as a {@code java.util.Date} object.
+     * @return The validated date.
+     * @throws IllegalValueException If validation fails.
      */
-    private Date checkDate() throws IllegalValueException {
+    private Date getValidatedDate() throws IllegalValueException {
         try {
             String dateStr = getDateFormat().format(date);
             getDateFormat().parse(dateStr);
@@ -128,10 +132,11 @@ public class JsonAdaptedLoan {
     }
 
     /**
-     * Checks that adapted description can be converted into model's {@code Description} object.
-     * @throws IllegalValueException If adapted object cannot be converted.
+     * Validates and converts the adapted description into the model's {@code Description} object.
+     * @return The validated and converted description.
+     * @throws IllegalValueException If validation fails.
      */
-    private Description checkDescription() throws IllegalValueException {
+    private Description getValidatedDescription() throws IllegalValueException {
         if (description == null) {
             throw new IllegalValueException(
                     String.format(MISSING_FIELD_MESSAGE_FORMAT, Description.class.getSimpleName()));
@@ -143,10 +148,11 @@ public class JsonAdaptedLoan {
     }
 
     /**
-     * Checks that adapted status can be converted into model's {@code Status} object.
-     * @throws IllegalValueException If adapted object cannot be converted.
+     * Validates and converts the adapted status into the model's {@code Status} object.
+     * @return The validated and converted status.
+     * @throws IllegalValueException If validation fails.
      */
-    private Status checkStatus() throws IllegalValueException {
+    private Status getValidatedStatus() throws IllegalValueException {
         if (status == null) {
             throw new IllegalValueException(
                     String.format(MISSING_FIELD_MESSAGE_FORMAT, Status.class.getSimpleName()));


### PR DESCRIPTION
- Add `getDateFormat()` in `AppUtil.java`, which returns a `SimpleDateFormat` for use in formatting/parsing
- Change the names of check methods in `JsonAdaptedLoan` as per request in #62 