### PR TITLE
Replace Apache Math library with own combinations generator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,9 +64,6 @@ dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
 
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
-
-    // Apache Commons
-    compile 'org.apache.commons:commons-math3:3.6.1'
 }
 
 shadowJar {

--- a/src/main/java/budgetbuddy/commons/util/CollectionUtil.java
+++ b/src/main/java/budgetbuddy/commons/util/CollectionUtil.java
@@ -2,11 +2,14 @@ package budgetbuddy.commons.util;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -50,4 +53,44 @@ public class CollectionUtil {
         return false;
     }
     //@@author
+
+    /**
+     * Returns a list of all combinations possible for a given list of items.
+     * @return A {@code List} of {@code List}s of the given items.
+     */
+    public static <T> List<List<T>> generateCombinations(List<T> items) {
+        List<List<T>> results = new ArrayList<List<T>>();
+        for (int i = 0; i < items.size(); i++) {
+            results.addAll(generateCombinations(items, i));
+        }
+        return results;
+    }
+
+    /**
+     * Returns a list of r-element combinations possible for a given list of items.
+     * @param r The number of elements for each combination.
+     * @return A {@code List} of size {@code r} {@code List}s of the given items.
+     */
+    public static <T> List<List<T>> generateCombinations(List<T> items, int r) {
+        List<List<T>> results = new ArrayList<List<T>>();
+
+        if (r == 0) {
+            return results;
+        }
+
+        if (r == 1 || items.size() <= 1) {
+            results.add(new ArrayList<T>(items));
+            return results;
+        }
+
+        for (int i = 0; i < items.size(); i++) {
+            final int currIndex = i;
+            List<T> itemsAfterCurrIndex = new ArrayList<T>(items.subList(currIndex + 1, items.size()));
+            results.addAll(generateCombinations(itemsAfterCurrIndex, r - 1)
+                    .stream()
+                    .peek(list -> list.add(0, items.get(currIndex)))
+                    .collect(Collectors.toList()));
+        }
+        return results;
+    }
 }

--- a/src/main/java/budgetbuddy/logic/commands/loancommands/LoanSplitCommand.java
+++ b/src/main/java/budgetbuddy/logic/commands/loancommands/LoanSplitCommand.java
@@ -196,10 +196,8 @@ public class LoanSplitCommand extends Command {
         }
 
         while (participants.size() > 1) {
-            participants.sort(balanceIncreasing); // participants MUST be sorted in the order of increasing balance
-
-            Participant debtor = participants.get(0);
-            Participant creditor = participants.get(participants.size() - 1);
+            Participant debtor = participants.stream().min(balanceIncreasing).get();
+            Participant creditor = participants.stream().max(balanceIncreasing).get();
 
             // transfer money between the biggest debtor and biggest creditor
             long amountTransferred = 0;
@@ -215,10 +213,10 @@ public class LoanSplitCommand extends Command {
             }
 
             if (debtor.getBalance() == 0) {
-                participants.remove(0);
+                participants.remove(debtor);
             }
             if (creditor.getBalance() == 0) {
-                participants.remove(participants.size() - 1);
+                participants.remove(creditor);
             }
 
             if (amountTransferred != 0) {

--- a/src/main/java/budgetbuddy/logic/commands/loancommands/LoanSplitCommand.java
+++ b/src/main/java/budgetbuddy/logic/commands/loancommands/LoanSplitCommand.java
@@ -271,6 +271,7 @@ public class LoanSplitCommand extends Command {
         HashMap<Person, Amount> currCreditors = new HashMap<Person, Amount>();
         for (DebtorCreditorAmount dca : debtorCreditorAmountList) {
             if (!dca.debtor.equals(currDebtor)) {
+                // new debtor reached in sorted list; add current debtor to list of debtors
                 debtors.add(new Debtor(currDebtor, currCreditors));
                 currDebtor = dca.debtor;
                 currCreditors.clear();

--- a/src/main/java/budgetbuddy/logic/commands/loancommands/LoanSplitCommand.java
+++ b/src/main/java/budgetbuddy/logic/commands/loancommands/LoanSplitCommand.java
@@ -198,6 +198,11 @@ public class LoanSplitCommand extends Command {
 
         List<DebtorCreditorAmount> debtorCreditorAmountList = new ArrayList<DebtorCreditorAmount>();
 
+        if (participants.stream().noneMatch(p -> p.getBalance() != 0)) {
+            participants.clear();
+            return debtorCreditorAmountList;
+        }
+
         while (participants.size() > 1) {
             participants.sort(balanceIncreasing); // participants MUST be sorted in the order of increasing balance
 

--- a/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanCommandParser.java
+++ b/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanCommandParser.java
@@ -51,10 +51,10 @@ public class LoanCommandParser implements CommandParser<LoanCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LoanCommand.MESSAGE_USAGE));
         }
 
-        if (argMultimap.getAllValues(PREFIX_PERSON).size() > 1
-                || argMultimap.getAllValues(PREFIX_AMOUNT).size() > 1
-                || argMultimap.getAllValues(PREFIX_DESCRIPTION).size() > 1
-                || argMultimap.getAllValues(PREFIX_DATE).size() > 1) {
+        if (argMultimap.getValueCount(PREFIX_PERSON) > 1
+                || argMultimap.getValueCount(PREFIX_AMOUNT) > 1
+                || argMultimap.getValueCount(PREFIX_DESCRIPTION) > 1
+                || argMultimap.getValueCount(PREFIX_DATE) > 1) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LoanCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanEditCommandParser.java
+++ b/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanEditCommandParser.java
@@ -32,10 +32,10 @@ public class LoanEditCommandParser implements CommandParser<LoanEditCommand> {
         ArgumentMultimap argMultiMap =
                 ArgumentTokenizer.tokenize(args, PREFIX_PERSON, PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE);
 
-        if (argMultiMap.getAllValues(PREFIX_PERSON).size() > 1
-                || argMultiMap.getAllValues(PREFIX_AMOUNT).size() > 1
-                || argMultiMap.getAllValues(PREFIX_DESCRIPTION).size() > 1
-                || argMultiMap.getAllValues(PREFIX_DATE).size() > 1) {
+        if (argMultiMap.getValueCount(PREFIX_PERSON) > 1
+                || argMultiMap.getValueCount(PREFIX_AMOUNT) > 1
+                || argMultiMap.getValueCount(PREFIX_DESCRIPTION) > 1
+                || argMultiMap.getValueCount(PREFIX_DATE) > 1) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LoanEditCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanListCommandParser.java
+++ b/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanListCommandParser.java
@@ -61,12 +61,14 @@ public class LoanListCommandParser implements CommandParser<LoanListCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LoanListCommand.MESSAGE_USAGE));
         }
 
+        // parse sort arguments
         Optional<Comparator<Loan>> optionalSorter = argMultimap.getValue(PREFIX_SORT).isPresent()
                 ? parseSortArg(argMultimap.getValue(PREFIX_SORT))
                 : Optional.empty();
 
         List<Predicate<Loan>> filters = new ArrayList<Predicate<Loan>>();
 
+        // parse direction and status filters
         if (!argMultimap.getPreamble().isBlank()) {
             String[] preambleArr = argMultimap.getPreamble().split("\\s+");
             if (preambleArr.length <= 2) {
@@ -76,6 +78,7 @@ public class LoanListCommandParser implements CommandParser<LoanListCommand> {
             }
         }
 
+        // parse person, amount, date and description filters
         for (String personStr : argMultimap.getAllValues(PREFIX_PERSON)) {
             filters.add(new PersonMatchPredicate(new Person(CommandParserUtil.parseName(personStr))));
         }

--- a/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanSplitCommandParser.java
+++ b/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanSplitCommandParser.java
@@ -45,6 +45,8 @@ public class LoanSplitCommandParser implements CommandParser<LoanSplitCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LoanSplitCommand.MESSAGE_USAGE));
         }
 
+        // parse optional user input for auto-adding calculated results to loan list
+
         Optional<String> optionalUserArg = argMultiMap.getValue(PREFIX_USER);
         Optional<Person> optionalUser = optionalUserArg.isPresent()
                 ? Optional.of(new Person(CommandParserUtil.parseName(optionalUserArg.get())))
@@ -64,6 +66,8 @@ public class LoanSplitCommandParser implements CommandParser<LoanSplitCommand> {
             || (optionalUser.isEmpty() && optionalDate.isPresent())) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LoanSplitCommand.MESSAGE_USAGE));
         }
+
+        // parse lists of persons and amounts
 
         List<Person> persons = new ArrayList<Person>();
         List<Amount> amounts = new ArrayList<Amount>();

--- a/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanSplitCommandParser.java
+++ b/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanSplitCommandParser.java
@@ -37,11 +37,11 @@ public class LoanSplitCommandParser implements CommandParser<LoanSplitCommand> {
         ArgumentMultimap argMultiMap = ArgumentTokenizer.tokenize(
                 args, PREFIX_USER, PREFIX_DESCRIPTION, PREFIX_DATE, PREFIX_PERSON, PREFIX_AMOUNT);
 
-        if (argMultiMap.getAllValues(PREFIX_USER).size() > 1
-                || argMultiMap.getAllValues(PREFIX_DESCRIPTION).size() > 1
-                || argMultiMap.getAllValues(PREFIX_DATE).size() > 1
-                || argMultiMap.getAllValues(PREFIX_PERSON).size() < 1
-                || argMultiMap.getAllValues(PREFIX_AMOUNT).size() < 1) {
+        if (argMultiMap.getValueCount(PREFIX_USER) > 1
+                || argMultiMap.getValueCount(PREFIX_DESCRIPTION) > 1
+                || argMultiMap.getValueCount(PREFIX_DATE) > 1
+                || argMultiMap.getValueCount(PREFIX_PERSON) < 1
+                || argMultiMap.getValueCount(PREFIX_AMOUNT) < 1) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LoanSplitCommand.MESSAGE_USAGE));
         }
 


### PR DESCRIPTION
- Remove Apache Commons math library
- Add `generateCombinations(List<T> items)` and `generateCombinations(List<T> items, int r)` to `CollectionUtil`
- Change checks for token input count to use `ArgumentMultimap#getValueCount`