### PR TITLE
Numerous fixes for loans and amount class

### DIFF
--- a/src/main/java/budgetbuddy/commons/core/index/Index.java
+++ b/src/main/java/budgetbuddy/commons/core/index/Index.java
@@ -56,4 +56,9 @@ public class Index {
     public String toString() {
         return zeroBasedIndex + "";
     }
+
+    @Override
+    public int hashCode() {
+        return Integer.hashCode(zeroBasedIndex);
+    }
 }

--- a/src/main/java/budgetbuddy/commons/util/CollectionUtil.java
+++ b/src/main/java/budgetbuddy/commons/util/CollectionUtil.java
@@ -69,7 +69,7 @@ public class CollectionUtil {
     /**
      * Returns a list of r-element combinations possible for a given list of items.
      * @param r The number of elements for each combination.
-     * @return A {@code List} of size {@code r} {@code List}s of the given items.
+     * @return A {@code List} of size-{@code r} combinations of items from {@code items}.
      */
     public static <T> List<List<T>> generateCombinations(List<T> items, int r) {
         List<List<T>> results = new ArrayList<List<T>>();

--- a/src/main/java/budgetbuddy/logic/commands/loancommands/MultiLoanCommand.java
+++ b/src/main/java/budgetbuddy/logic/commands/loancommands/MultiLoanCommand.java
@@ -88,8 +88,7 @@ public abstract class MultiLoanCommand extends Command {
             }
         }
 
-        targetLoanIndices = targetLoanIndices.stream().distinct().collect(Collectors.toList());
-        return targetLoanIndices;
+        return targetLoanIndices.stream().distinct().collect(Collectors.toList());
     }
 
 

--- a/src/main/java/budgetbuddy/logic/commands/loancommands/UpdateStatusCommand.java
+++ b/src/main/java/budgetbuddy/logic/commands/loancommands/UpdateStatusCommand.java
@@ -8,6 +8,7 @@ import java.util.function.Consumer;
 import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.logic.commands.exceptions.CommandException;
 import budgetbuddy.model.LoansManager;
+import budgetbuddy.model.loan.Loan;
 import budgetbuddy.model.loan.Status;
 import budgetbuddy.model.person.Person;
 
@@ -27,8 +28,22 @@ public abstract class UpdateStatusCommand extends MultiLoanCommand {
         requireAllNonNull(loansManager, updatedStatus);
 
         List<Index> targetLoanIndices = constructTargetLoanIndicesList(loansManager);
-        Consumer<Index> updateStatusOp = targetIndex -> loansManager.updateLoanStatus(targetIndex, updatedStatus);
+        Consumer<Index> updateStatusOp = targetIndex -> {
+            Loan updatedLoan = createUpdatedLoan(loansManager.getLoan(targetIndex), updatedStatus);
+            loansManager.editLoan(targetIndex, updatedLoan);
+        };
 
         actOnTargetLoans(targetLoanIndices, updateStatusOp);
+    }
+
+    /**
+     * Creates a new {@code Loan} with the updated {@code Status}.
+     * @param oldLoan The {@code Loan} targeted for a status update.
+     * @param updatedStatus The new {@code Status}.
+     * @return The new, updated {@code Loan}.
+     */
+    private Loan createUpdatedLoan(Loan oldLoan, Status updatedStatus) {
+        return new Loan(oldLoan.getPerson(), oldLoan.getDirection(), oldLoan.getAmount(),
+                oldLoan.getDate(), oldLoan.getDescription(), updatedStatus);
     }
 }

--- a/src/main/java/budgetbuddy/logic/parser/CommandParserUtil.java
+++ b/src/main/java/budgetbuddy/logic/parser/CommandParserUtil.java
@@ -88,6 +88,10 @@ public class CommandParserUtil {
             throw new ParseException(Amount.MESSAGE_CONSTRAINTS);
         }
 
+        if (dollarCentArray[0].length() > Amount.MAX_AMOUNT.length()) {
+            throw new ParseException(Amount.MESSAGE_CONSTRAINTS);
+        }
+
         Long parsedDollars;
         if (StringUtil.isNonNegativeUnsignedLong(dollarCentArray[0])) {
             parsedDollars = Long.parseLong(dollarCentArray[0]) * 100L;

--- a/src/main/java/budgetbuddy/model/LoansManager.java
+++ b/src/main/java/budgetbuddy/model/LoansManager.java
@@ -11,7 +11,6 @@ import java.util.function.Predicate;
 import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.model.loan.Debtor;
 import budgetbuddy.model.loan.Loan;
-import budgetbuddy.model.loan.Status;
 import budgetbuddy.model.loan.exceptions.LoanNotFoundException;
 
 import javafx.collections.FXCollections;
@@ -133,16 +132,6 @@ public class LoansManager {
     public void editLoan(Index toEdit, Loan editedLoan) throws LoanNotFoundException {
         checkIndexValidity(toEdit);
         internalList.set(toEdit.getZeroBased(), editedLoan);
-    }
-
-    /**
-     * Updates the status of a target loan to the given status.
-     * @param toUpdate The index of the target loan to update.
-     * @param newStatus The new status to update the target loan to.
-     */
-    public void updateLoanStatus(Index toUpdate, Status newStatus) {
-        checkIndexValidity(toUpdate);
-        internalList.get(toUpdate.getZeroBased()).setStatus(newStatus);
     }
 
     /**

--- a/src/main/java/budgetbuddy/model/attributes/Description.java
+++ b/src/main/java/budgetbuddy/model/attributes/Description.java
@@ -8,8 +8,10 @@ import static java.util.Objects.requireNonNull;
  */
 public class Description {
 
+    public static final int MAX_LENGTH = 180;
+
     public static final String MESSAGE_CONSTRAINTS =
-            "Description should not be null.";
+            "Description should not be blank and should be no more than " + MAX_LENGTH + " characters.";
 
     private String description;
 
@@ -20,7 +22,8 @@ public class Description {
     }
 
     public static boolean isValidDescription(String description) {
-        return description != null;
+        return description != null
+                && description.length() <= MAX_LENGTH;
     }
 
     public String getDescription() {

--- a/src/main/java/budgetbuddy/model/attributes/Description.java
+++ b/src/main/java/budgetbuddy/model/attributes/Description.java
@@ -11,7 +11,7 @@ public class Description {
     public static final int MAX_LENGTH = 180;
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Description should not be blank and should be no more than " + MAX_LENGTH + " characters.";
+            "Description should be no more than " + MAX_LENGTH + " characters.";
 
     private String description;
 
@@ -21,9 +21,12 @@ public class Description {
         this.description = description;
     }
 
+    /**
+     * Returns true if the given string description is no more than {@link #MAX_LENGTH} characters.
+     */
     public static boolean isValidDescription(String description) {
-        return description != null
-                && description.length() <= MAX_LENGTH;
+        requireNonNull(description);
+        return description.length() <= MAX_LENGTH;
     }
 
     public String getDescription() {

--- a/src/main/java/budgetbuddy/model/loan/Loan.java
+++ b/src/main/java/budgetbuddy/model/loan/Loan.java
@@ -17,13 +17,12 @@ import budgetbuddy.model.transaction.Amount;
  */
 public class Loan {
 
+    private final Person person;
     private final Direction direction;
     private final Amount amount;
     private final Date date;
     private final Description description;
-
-    private Person person;
-    private Status status;
+    private final Status status;
 
     /**
      * Every field must be present and not null.
@@ -41,10 +40,6 @@ public class Loan {
 
     public Person getPerson() {
         return person;
-    }
-
-    public void setPerson(Person person) {
-        this.person = person;
     }
 
     public Direction getDirection() {
@@ -69,10 +64,6 @@ public class Loan {
 
     public Status getStatus() {
         return status;
-    }
-
-    public void setStatus(Status status) {
-        this.status = status;
     }
 
     /**
@@ -105,6 +96,7 @@ public class Loan {
             return false;
         }
 
+        // do not compare status of loan
         Loan otherLoan = (Loan) other;
         return otherLoan.getPerson().isSamePerson(person)
                 && otherLoan.getDirection() == direction

--- a/src/main/java/budgetbuddy/model/transaction/Amount.java
+++ b/src/main/java/budgetbuddy/model/transaction/Amount.java
@@ -9,9 +9,11 @@ import budgetbuddy.commons.util.AppUtil;
 public class Amount {
 
     public static final String CURRENCY_SIGN = "$";
+    public static final String MAX_AMOUNT = "9999999999999999";
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Amounts should be non-negative numbers and should not be blank.";
+            "Amounts should be non-negative numbers, should not be blank, "
+                    + "and should not exceed " + CURRENCY_SIGN + MAX_AMOUNT + ".";
     public static final String MESSAGE_CENTS_PARSE_ERROR =
             "Cents should be at most two decimal places long.";
 

--- a/src/main/java/budgetbuddy/ui/card/LoanCard.java
+++ b/src/main/java/budgetbuddy/ui/card/LoanCard.java
@@ -7,7 +7,6 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
-import javafx.scene.text.Font;
 
 /**
  * A UI component that displays information of a {@code Loan}.

--- a/src/main/java/budgetbuddy/ui/card/LoanCard.java
+++ b/src/main/java/budgetbuddy/ui/card/LoanCard.java
@@ -38,6 +38,7 @@ public class LoanCard extends UiPart<Region> {
         amountDirectionPerson.setText(loan.getEssentialInfo());
         date.setText(loan.getDateString());
         description.setText(loan.getDescription().toString());
+        description.setWrapText(true);
         status.setText(loan.getStatus().getStatusIcon());
         status.setStyle("-fx-font-size: 48");
     }

--- a/src/main/java/budgetbuddy/ui/card/LoanCard.java
+++ b/src/main/java/budgetbuddy/ui/card/LoanCard.java
@@ -7,6 +7,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import javafx.scene.text.Font;
 
 /**
  * A UI component that displays information of a {@code Loan}.
@@ -38,6 +39,7 @@ public class LoanCard extends UiPart<Region> {
         date.setText(loan.getDateString());
         description.setText(loan.getDescription().toString());
         status.setText(loan.getStatus().getStatusIcon());
+        status.setStyle("-fx-font-size: 48");
     }
 
     @Override

--- a/src/main/java/budgetbuddy/ui/panel/LoanPanel.java
+++ b/src/main/java/budgetbuddy/ui/panel/LoanPanel.java
@@ -43,7 +43,6 @@ public class LoanPanel extends DisplayPanel {
                 setGraphic(new LoanCard(loan, getIndex() + 1).getRoot());
                 setMouseTransparent(true);
                 setFocusTraversable(false);
-                loanListView.refresh();
             }
         }
     }

--- a/src/main/resources/view/LoanCard.fxml
+++ b/src/main/resources/view/LoanCard.fxml
@@ -29,7 +29,7 @@
             </padding>
             <Label fx:id="amountDirectionPerson" text="\$first" styleClass="cell_big_label" />
             <Label fx:id="date" styleClass="cell_small_label" text="\$date" />
-            <Label fx:id="description" styleClass="cell_small_label" text="\$description" />
+            <Label fx:id="description" styleClass="cell_small_label" text="\$description" prefWidth="400" />
         </VBox>
         <VBox alignment="CENTER" minHeight="105" GridPane.columnIndex="2">
             <padding>

--- a/src/main/resources/view/LoanCard.fxml
+++ b/src/main/resources/view/LoanCard.fxml
@@ -12,10 +12,10 @@
             <ColumnConstraints percentWidth="5"/>
         </columnConstraints>
         <columnConstraints>
-            <ColumnConstraints percentWidth="80" />
+            <ColumnConstraints percentWidth="70" />
         </columnConstraints>
         <columnConstraints>
-            <ColumnConstraints percentWidth="15"/>
+            <ColumnConstraints percentWidth="25"/>
         </columnConstraints>
         <VBox alignment="CENTER" minHeight="105" GridPane.columnIndex="0">
             <padding>


### PR DESCRIPTION
- Fix incorrect deletion of loans when input is a mix of indices and persons e.g. `loan delete 1 p/John`
- Tweak combinations generator Javadoc, closes #91 
- Fix loan paid/unpaid command not updating status icon in GUI
- Prevent `parseAmount` from parsing values greater than `Long.MAX_VALUE`, fixes #101 
- Add maximum length to `Description`