### PR TITLE
Fix rules to allow multiple edits to the same transaction in 1 pass

### DIFF
--- a/src/main/java/budgetbuddy/logic/commands/transactioncommands/TransactionAddCommand.java
+++ b/src/main/java/budgetbuddy/logic/commands/transactioncommands/TransactionAddCommand.java
@@ -12,6 +12,7 @@ import static budgetbuddy.logic.parser.CliSyntax.PREFIX_DIRECTION;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_RECURRENCE;
 import static java.util.Objects.requireNonNull;
 
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.logic.commands.CommandCategory;
 import budgetbuddy.logic.commands.CommandResult;
 import budgetbuddy.logic.commands.exceptions.CommandException;
@@ -83,7 +84,8 @@ public class TransactionAddCommand extends ScriptCommand {
         } catch (Exception e) {
             return new CommandResult(MESSAGE_FAILURE, CommandCategory.TRANSACTION);
         }
-        RuleEngine.executeRules(model, scriptEngine, toAdd, realToAccount);
+        Index txnIndex = Index.fromOneBased(realToAccount.getTransactionList().getTransactionsCount());
+        RuleEngine.executeRules(model, scriptEngine, txnIndex, realToAccount);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), CommandCategory.TRANSACTION);
     }

--- a/src/main/java/budgetbuddy/logic/commands/transactioncommands/TransactionEditCommand.java
+++ b/src/main/java/budgetbuddy/logic/commands/transactioncommands/TransactionEditCommand.java
@@ -102,8 +102,9 @@ public class TransactionEditCommand extends ScriptCommand {
                     targetAccount, model.getAccountsManager().getActiveAccount());
 
 
-            accountsManager.getAccount(targetAccount.getName()).addTransaction(updatedTransaction);
-            RuleEngine.executeRules(model, scriptEngine, updatedTransaction, targetAccount);
+            targetAccount.addTransaction(updatedTransaction);
+            Index updatedTxnIndex = Index.fromOneBased(targetAccount.getTransactionList().getTransactionsCount());
+            RuleEngine.executeRules(model, scriptEngine, updatedTxnIndex, targetAccount);
 
         } catch (TransactionNotFoundException e) {
             throw new CommandException(MESSAGE_FAILURE);

--- a/src/main/java/budgetbuddy/logic/rules/performable/Performable.java
+++ b/src/main/java/budgetbuddy/logic/rules/performable/Performable.java
@@ -1,8 +1,8 @@
 package budgetbuddy.logic.rules.performable;
 
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.model.Model;
 import budgetbuddy.model.account.Account;
-import budgetbuddy.model.transaction.Transaction;
 
 /**
  * Represents an action with hidden internal logic and the ability to be performed.
@@ -11,5 +11,5 @@ public interface Performable {
     /**
      * Executes the action.
      */
-    void perform(Model model, Transaction txn, Account account);
+    void perform(Model model, Index txnIndex, Account account);
 }

--- a/src/main/java/budgetbuddy/logic/rules/performable/PerformableScript.java
+++ b/src/main/java/budgetbuddy/logic/rules/performable/PerformableScript.java
@@ -2,9 +2,9 @@ package budgetbuddy.logic.rules.performable;
 
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.model.Model;
 import budgetbuddy.model.account.Account;
-import budgetbuddy.model.transaction.Transaction;
 
 /**
  * Represents an action written as a script.
@@ -22,8 +22,8 @@ public class PerformableScript implements Performable {
     }
 
     @Override
-    public void perform(Model model, Transaction txn, Account account) {
-        evaluator.run(txn, account);
+    public void perform(Model model, Index txnIndex, Account account) {
+        evaluator.run(txnIndex, account);
     }
 
     /**
@@ -34,6 +34,6 @@ public class PerformableScript implements Performable {
         /**
          * Executes the script and returns the result.
          */
-        void run(Transaction txn, Account account);
+        void run(Index txnIndex, Account account);
     }
 }

--- a/src/main/java/budgetbuddy/logic/rules/performable/PrependDescriptionExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/performable/PrependDescriptionExpression.java
@@ -2,9 +2,9 @@ package budgetbuddy.logic.rules.performable;
 
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.logic.parser.CommandParserUtil;
 import budgetbuddy.logic.parser.exceptions.ParseException;
-import budgetbuddy.model.AccountsManager;
 import budgetbuddy.model.Model;
 import budgetbuddy.model.account.Account;
 import budgetbuddy.model.attributes.Description;
@@ -26,21 +26,20 @@ public class PrependDescriptionExpression extends PerformableExpression {
     }
 
     @Override
-    public void perform(Model model, Transaction txn, Account account) {
-        requireAllNonNull(model, model.getAccountsManager(), txn);
+    public void perform(Model model, Index txnIndex, Account account) {
+        requireAllNonNull(model, txnIndex);
 
-        AccountsManager accountsManager = model.getAccountsManager();
         try {
+            Transaction toEdit = account.getTransaction(txnIndex);
             Description updatedDesc = CommandParserUtil.parseDescription(value.toString()
-                    + txn.getDescription().toString());
+                    + toEdit.getDescription().toString());
 
-            Transaction updatedTransaction = new Transaction(txn.getDate(), txn.getAmount(), txn.getDirection(),
-                    updatedDesc, txn.getCategories());
+            Transaction updatedTransaction = new Transaction(toEdit.getDate(), toEdit.getAmount(),
+                    toEdit.getDirection(), updatedDesc, toEdit.getCategories());
 
-            accountsManager.getActiveAccount().deleteTransaction(txn);
-            accountsManager.getAccount(account.getName()).addTransaction(updatedTransaction);
+            account.updateTransaction(txnIndex, updatedTransaction);
 
-            logger.info("Rule Execution———Description updated in " + updatedTransaction);
+            logger.info("Rule Execution———Description updated in:\n" + updatedTransaction);
         } catch (ParseException e) {
             // Should not happen as value should be parsable by the time this method is called
             // but will exit without completing if it does happen.

--- a/src/main/java/budgetbuddy/logic/rules/performable/SetCategoryExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/performable/SetCategoryExpression.java
@@ -5,9 +5,9 @@ import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.HashSet;
 import java.util.Set;
 
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.logic.parser.CommandParserUtil;
 import budgetbuddy.logic.parser.exceptions.ParseException;
-import budgetbuddy.model.AccountsManager;
 import budgetbuddy.model.Model;
 import budgetbuddy.model.account.Account;
 import budgetbuddy.model.attributes.Category;
@@ -29,12 +29,12 @@ public class SetCategoryExpression extends PerformableExpression {
     }
 
     @Override
-    public void perform(Model model, Transaction txn, Account account) {
-        requireAllNonNull(model, model.getAccountsManager(), txn);
+    public void perform(Model model, Index txnIndex, Account account) {
+        requireAllNonNull(model, txnIndex);
 
-        AccountsManager accountsManager = model.getAccountsManager();
         try {
-            Set<Category> categories = new HashSet<>(txn.getCategories());
+            Transaction toEdit = account.getTransaction(txnIndex);
+            Set<Category> categories = new HashSet<>(toEdit.getCategories());
 
             Category categoryToAdd = CommandParserUtil.parseCategory(value.toString());
             if (categories.contains(categoryToAdd)) {
@@ -42,13 +42,12 @@ public class SetCategoryExpression extends PerformableExpression {
             }
 
             categories.add(categoryToAdd);
-            Transaction updatedTransaction = new Transaction(txn.getDate(), txn.getAmount(), txn.getDirection(),
-                    txn.getDescription(), categories);
+            Transaction updatedTransaction = new Transaction(toEdit.getDate(), toEdit.getAmount(),
+                    toEdit.getDirection(), toEdit.getDescription(), categories);
 
-            accountsManager.getActiveAccount().deleteTransaction(txn);
-            accountsManager.getAccount(account.getName()).addTransaction(updatedTransaction);
+            account.updateTransaction(txnIndex, updatedTransaction);
 
-            logger.info("Rule Execution———Category added in " + updatedTransaction);
+            logger.info("Rule Execution———Category added in:\n" + updatedTransaction);
         } catch (ParseException e) {
             // Should not happen as value should be parsable by the time this method is called
             // but will exit without completing if it does happen.

--- a/src/main/java/budgetbuddy/logic/rules/performable/SetDescriptionExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/performable/SetDescriptionExpression.java
@@ -2,9 +2,9 @@ package budgetbuddy.logic.rules.performable;
 
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.logic.parser.CommandParserUtil;
 import budgetbuddy.logic.parser.exceptions.ParseException;
-import budgetbuddy.model.AccountsManager;
 import budgetbuddy.model.Model;
 import budgetbuddy.model.account.Account;
 import budgetbuddy.model.attributes.Description;
@@ -26,21 +26,19 @@ public class SetDescriptionExpression extends PerformableExpression {
     }
 
     @Override
-    public void perform(Model model, Transaction txn, Account account) {
-        requireAllNonNull(model, model.getAccountsManager(), txn);
+    public void perform(Model model, Index txnIndex, Account account) {
+        requireAllNonNull(model, txnIndex);
 
-        AccountsManager accountsManager = model.getAccountsManager();
         try {
+            Transaction toEdit = account.getTransaction(txnIndex);
             Description updatedDesc = CommandParserUtil.parseDescription(value.toString());
 
-            Transaction updatedTransaction = new Transaction(txn.getDate(), txn.getAmount(), txn.getDirection(),
-                    updatedDesc, txn.getCategories());
+            Transaction updatedTransaction = new Transaction(toEdit.getDate(), toEdit.getAmount(),
+                    toEdit.getDirection(), updatedDesc, toEdit.getCategories());
 
-            accountsManager.getActiveAccount().deleteTransaction(txn);
-            accountsManager.getAccount(account.getName()).addTransaction(updatedTransaction);
+            account.updateTransaction(txnIndex, updatedTransaction);
 
-            logger.info("Rule Execution———Description updated in " + updatedTransaction);
-            System.out.println(updatedDesc);
+            logger.info("Rule Execution———Description updated in:\n" + updatedTransaction);
         } catch (ParseException e) {
             // Should not happen as value should be parsable by the time this method is called
             // but will exit without completing if it does happen.

--- a/src/main/java/budgetbuddy/logic/rules/performable/SetInwardExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/performable/SetInwardExpression.java
@@ -2,7 +2,7 @@ package budgetbuddy.logic.rules.performable;
 
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
-import budgetbuddy.model.AccountsManager;
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.model.Model;
 import budgetbuddy.model.account.Account;
 import budgetbuddy.model.attributes.Direction;
@@ -24,18 +24,17 @@ public class SetInwardExpression extends PerformableExpression {
     }
 
     @Override
-    public void perform(Model model, Transaction txn, Account account) {
-        requireAllNonNull(model, model.getAccountsManager(), txn);
+    public void perform(Model model, Index txnIndex, Account account) {
+        requireAllNonNull(model, txnIndex);
 
-        AccountsManager accountsManager = model.getAccountsManager();
+        Transaction toEdit = account.getTransaction(txnIndex);
         Direction updatedDirection = Direction.IN;
 
-        Transaction updatedTransaction = new Transaction(txn.getDate(), txn.getAmount(), updatedDirection,
-                txn.getDescription(), txn.getCategories());
+        Transaction updatedTransaction = new Transaction(toEdit.getDate(), toEdit.getAmount(), updatedDirection,
+                toEdit.getDescription(), toEdit.getCategories());
 
-        accountsManager.getActiveAccount().deleteTransaction(txn);
-        accountsManager.getAccount(account.getName()).addTransaction(updatedTransaction);
+        account.updateTransaction(txnIndex, updatedTransaction);
 
-        logger.info("Rule Execution———Direction updated in " + updatedTransaction);
+        logger.info("Rule Execution———Direction updated in:\n" + updatedTransaction);
     }
 }

--- a/src/main/java/budgetbuddy/logic/rules/performable/SetOutwardExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/performable/SetOutwardExpression.java
@@ -2,7 +2,7 @@ package budgetbuddy.logic.rules.performable;
 
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
-import budgetbuddy.model.AccountsManager;
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.model.Model;
 import budgetbuddy.model.account.Account;
 import budgetbuddy.model.attributes.Direction;
@@ -24,18 +24,17 @@ public class SetOutwardExpression extends PerformableExpression {
     }
 
     @Override
-    public void perform(Model model, Transaction txn, Account account) {
-        requireAllNonNull(model, model.getAccountsManager(), txn);
+    public void perform(Model model, Index txnIndex, Account account) {
+        requireAllNonNull(model, txnIndex);
 
-        AccountsManager accountsManager = model.getAccountsManager();
+        Transaction toEdit = account.getTransaction(txnIndex);
         Direction updatedDirection = Direction.OUT;
 
-        Transaction updatedTransaction = new Transaction(txn.getDate(), txn.getAmount(), updatedDirection,
-                txn.getDescription(), txn.getCategories());
+        Transaction updatedTransaction = new Transaction(toEdit.getDate(), toEdit.getAmount(), updatedDirection,
+                toEdit.getDescription(), toEdit.getCategories());
 
-        accountsManager.getActiveAccount().deleteTransaction(txn);
-        accountsManager.getAccount(account.getName()).addTransaction(updatedTransaction);
+        account.updateTransaction(txnIndex, updatedTransaction);
 
-        logger.info("Rule Execution———Direction updated in " + updatedTransaction);
+        logger.info("Rule Execution———Direction updated in:\n" + updatedTransaction);
     }
 }

--- a/src/main/java/budgetbuddy/logic/rules/performable/SwitchDirectionExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/performable/SwitchDirectionExpression.java
@@ -2,7 +2,7 @@ package budgetbuddy.logic.rules.performable;
 
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
-import budgetbuddy.model.AccountsManager;
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.model.Model;
 import budgetbuddy.model.account.Account;
 import budgetbuddy.model.attributes.Direction;
@@ -24,18 +24,17 @@ public class SwitchDirectionExpression extends PerformableExpression {
     }
 
     @Override
-    public void perform(Model model, Transaction txn, Account account) {
-        requireAllNonNull(model, model.getAccountsManager(), txn);
+    public void perform(Model model, Index txnIndex, Account account) {
+        requireAllNonNull(model, txnIndex);
 
-        AccountsManager accountsManager = model.getAccountsManager();
-        Direction updatedDirection = txn.getDirection().equals(Direction.IN) ? Direction.OUT : Direction.IN;
+        Transaction toEdit = account.getTransaction(txnIndex);
+        Direction updatedDirection = toEdit.getDirection().equals(Direction.IN) ? Direction.OUT : Direction.IN;
 
-        Transaction updatedTransaction = new Transaction(txn.getDate(), txn.getAmount(), updatedDirection,
-                txn.getDescription(), txn.getCategories());
+        Transaction updatedTransaction = new Transaction(toEdit.getDate(), toEdit.getAmount(), updatedDirection,
+                toEdit.getDescription(), toEdit.getCategories());
 
-        accountsManager.getActiveAccount().deleteTransaction(txn);
-        accountsManager.getAccount(account.getName()).addTransaction(updatedTransaction);
+        account.updateTransaction(txnIndex, updatedTransaction);
 
-        logger.info("Rule Execution———Direction updated in " + updatedTransaction);
+        logger.info("Rule Execution———Direction updated in:\n" + updatedTransaction);
     }
 }

--- a/src/main/java/budgetbuddy/logic/rules/testable/ContainsExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/testable/ContainsExpression.java
@@ -1,12 +1,12 @@
 package budgetbuddy.logic.rules.testable;
 
-import static java.util.Objects.requireNonNull;
+import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.logic.rules.RuleEngine;
 import budgetbuddy.model.account.Account;
 import budgetbuddy.model.rule.expression.Attribute;
 import budgetbuddy.model.rule.expression.Value;
-import budgetbuddy.model.transaction.Transaction;
 
 /**
  * Represents a contains expression.
@@ -23,9 +23,9 @@ public class ContainsExpression extends TestableExpression {
     }
 
     @Override
-    public boolean test(Transaction txn, Account account) {
-        requireNonNull(txn);
-        String left = RuleEngine.extractAttribute(attribute, txn).toString();
+    public boolean test(Index txnIndex, Account account) {
+        requireAllNonNull(txnIndex, account);
+        String left = RuleEngine.extractAttribute(attribute, txnIndex, account).toString();
         String right = value.toString();
         return left.contains(right);
     }

--- a/src/main/java/budgetbuddy/logic/rules/testable/EqualToExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/testable/EqualToExpression.java
@@ -1,12 +1,12 @@
 package budgetbuddy.logic.rules.testable;
 
-import static java.util.Objects.requireNonNull;
+import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.logic.rules.RuleEngine;
 import budgetbuddy.model.account.Account;
 import budgetbuddy.model.rule.expression.Attribute;
 import budgetbuddy.model.rule.expression.Value;
-import budgetbuddy.model.transaction.Transaction;
 
 /**
  * Represents a equal-to expression.
@@ -23,9 +23,9 @@ public class EqualToExpression extends TestableExpression {
     }
 
     @Override
-    public boolean test(Transaction txn, Account account) {
-        requireNonNull(txn);
-        double left = (double) RuleEngine.extractAttribute(attribute, txn);
+    public boolean test(Index txnIndex, Account account) {
+        requireAllNonNull(txnIndex, account);
+        double left = (double) RuleEngine.extractAttribute(attribute, txnIndex, account);
         double right = Double.parseDouble(value.toString());
         return left == right;
     }

--- a/src/main/java/budgetbuddy/logic/rules/testable/LessEqualExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/testable/LessEqualExpression.java
@@ -1,12 +1,12 @@
 package budgetbuddy.logic.rules.testable;
 
-import static java.util.Objects.requireNonNull;
+import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.logic.rules.RuleEngine;
 import budgetbuddy.model.account.Account;
 import budgetbuddy.model.rule.expression.Attribute;
 import budgetbuddy.model.rule.expression.Value;
-import budgetbuddy.model.transaction.Transaction;
 
 /**
  * Represents a less-than-or-equal-to expression.
@@ -23,9 +23,9 @@ public class LessEqualExpression extends TestableExpression {
     }
 
     @Override
-    public boolean test(Transaction txn, Account account) {
-        requireNonNull(txn);
-        double left = (double) RuleEngine.extractAttribute(attribute, txn);
+    public boolean test(Index txnIndex, Account account) {
+        requireAllNonNull(txnIndex, account);
+        double left = (double) RuleEngine.extractAttribute(attribute, txnIndex, account);
         double right = Double.parseDouble(value.toString());
         return left >= 0 && left <= right;
     }

--- a/src/main/java/budgetbuddy/logic/rules/testable/LessThanExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/testable/LessThanExpression.java
@@ -1,12 +1,12 @@
 package budgetbuddy.logic.rules.testable;
 
-import static java.util.Objects.requireNonNull;
+import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.logic.rules.RuleEngine;
 import budgetbuddy.model.account.Account;
 import budgetbuddy.model.rule.expression.Attribute;
 import budgetbuddy.model.rule.expression.Value;
-import budgetbuddy.model.transaction.Transaction;
 
 /**
  * Represents a less-than expression.
@@ -23,9 +23,9 @@ public class LessThanExpression extends TestableExpression {
     }
 
     @Override
-    public boolean test(Transaction txn, Account account) {
-        requireNonNull(txn);
-        double left = (double) RuleEngine.extractAttribute(attribute, txn);
+    public boolean test(Index txnIndex, Account account) {
+        requireAllNonNull(txnIndex, account);
+        double left = (double) RuleEngine.extractAttribute(attribute, txnIndex, account);
         double right = Double.parseDouble(value.toString());
         return left >= 0 && left < right;
     }

--- a/src/main/java/budgetbuddy/logic/rules/testable/MoreEqualExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/testable/MoreEqualExpression.java
@@ -1,12 +1,12 @@
 package budgetbuddy.logic.rules.testable;
 
-import static java.util.Objects.requireNonNull;
+import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.logic.rules.RuleEngine;
 import budgetbuddy.model.account.Account;
 import budgetbuddy.model.rule.expression.Attribute;
 import budgetbuddy.model.rule.expression.Value;
-import budgetbuddy.model.transaction.Transaction;
 
 /**
  * Represents a more-than-or-equal-to expression.
@@ -23,9 +23,9 @@ public class MoreEqualExpression extends TestableExpression {
     }
 
     @Override
-    public boolean test(Transaction txn, Account account) {
-        requireNonNull(txn);
-        double left = (double) RuleEngine.extractAttribute(attribute, txn);
+    public boolean test(Index txnIndex, Account account) {
+        requireAllNonNull(txnIndex, account);
+        double left = (double) RuleEngine.extractAttribute(attribute, txnIndex, account);
         double right = Double.parseDouble(value.toString());
         return left >= 0 && left >= right;
     }

--- a/src/main/java/budgetbuddy/logic/rules/testable/MoreThanExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/testable/MoreThanExpression.java
@@ -1,12 +1,12 @@
 package budgetbuddy.logic.rules.testable;
 
-import static java.util.Objects.requireNonNull;
+import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.logic.rules.RuleEngine;
 import budgetbuddy.model.account.Account;
 import budgetbuddy.model.rule.expression.Attribute;
 import budgetbuddy.model.rule.expression.Value;
-import budgetbuddy.model.transaction.Transaction;
 
 /**
  * Represents a more-than expression.
@@ -23,9 +23,9 @@ public class MoreThanExpression extends TestableExpression {
     }
 
     @Override
-    public boolean test(Transaction txn, Account account) {
-        requireNonNull(txn);
-        double left = (double) RuleEngine.extractAttribute(attribute, txn);
+    public boolean test(Index txnIndex, Account account) {
+        requireAllNonNull(txnIndex, account);
+        double left = (double) RuleEngine.extractAttribute(attribute, txnIndex, account);
         double right = Double.parseDouble(value.toString());
         return left >= 0 && left > right;
     }

--- a/src/main/java/budgetbuddy/logic/rules/testable/Testable.java
+++ b/src/main/java/budgetbuddy/logic/rules/testable/Testable.java
@@ -1,7 +1,7 @@
 package budgetbuddy.logic.rules.testable;
 
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.model.account.Account;
-import budgetbuddy.model.transaction.Transaction;
 
 /**
  * Represents a predicate with hidden internal logic and the ability to be tested.
@@ -9,7 +9,7 @@ import budgetbuddy.model.transaction.Transaction;
 @FunctionalInterface
 public interface Testable {
     /**
-     * Tests if the transaction and account satisfy the predicate.
+     * Tests if the transaction in this account satisfy the predicate.
      */
-    boolean test(Transaction txn, Account account);
+    boolean test(Index txnIndex, Account account);
 }

--- a/src/main/java/budgetbuddy/logic/rules/testable/TestableScript.java
+++ b/src/main/java/budgetbuddy/logic/rules/testable/TestableScript.java
@@ -2,8 +2,8 @@ package budgetbuddy.logic.rules.testable;
 
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.model.account.Account;
-import budgetbuddy.model.transaction.Transaction;
 
 /**
  * Represents a predicate written as a script.
@@ -21,8 +21,8 @@ public class TestableScript implements Testable {
     }
 
     @Override
-    public boolean test(Transaction txn, Account account) {
-        return evaluator.run(txn, account);
+    public boolean test(Index txnIndex, Account account) {
+        return evaluator.run(txnIndex, account);
     }
 
     /**
@@ -33,6 +33,6 @@ public class TestableScript implements Testable {
         /**
          * Executes the script and returns the result.
          */
-        boolean run(Transaction txn, Account account);
+        boolean run(Index txnIndex, Account account);
     }
 }

--- a/src/main/java/budgetbuddy/model/account/Account.java
+++ b/src/main/java/budgetbuddy/model/account/Account.java
@@ -4,6 +4,7 @@ import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Objects;
 
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.model.attributes.Description;
 import budgetbuddy.model.attributes.Name;
 import budgetbuddy.model.transaction.Transaction;
@@ -43,8 +44,16 @@ public class Account {
         return transactionList;
     }
 
+    public Transaction getTransaction(Index toGet) {
+        return this.transactionList.getTransaction(toGet);
+    }
+
     public void addTransaction(Transaction toAdd) {
         this.transactionList.add(toAdd);
+    }
+
+    public void updateTransaction(Index txnIndex, Transaction editedTxn) {
+        this.transactionList.setTransaction(txnIndex, editedTxn);
     }
 
     public void deleteTransaction(Transaction toDelete) {

--- a/src/main/java/budgetbuddy/model/transaction/TransactionList.java
+++ b/src/main/java/budgetbuddy/model/transaction/TransactionList.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Iterator;
 
+import budgetbuddy.commons.core.index.Index;
 import budgetbuddy.model.transaction.exceptions.TransactionNotFoundException;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -36,19 +37,25 @@ public class TransactionList implements Iterable<Transaction> {
     }
 
     /**
-     * Replaces the Transaction {@code target} in the list with {@code editedTransaction}.
-     * {@code target} must exist in the list.
+     * Returns the Transaction at the specified index in the list.
+     * @param toGet The index of the target transaction.
+     * @throws TransactionNotFoundException If the transaction is not in the list.
      */
-    public void setTransaction(Transaction target, Transaction editedTransaction) {
-        requireAllNonNull(target, editedTransaction);
-
-        int index = internalList.indexOf(target);
-        if (index == -1) {
-            // TODO handle transactions not found
-            //throw new TransactionNotFoundException();
+    public Transaction getTransaction(Index toGet) throws TransactionNotFoundException {
+        if (toGet.getOneBased() > internalList.size()) {
+            throw new TransactionNotFoundException();
         }
+        return internalList.get(toGet.getZeroBased());
+    }
 
-        internalList.set(index, editedTransaction);
+    /**
+     * Replaces the Transaction at the index {@code txnIndex} in the list with {@code editedTransaction}.
+     * {@code txnIndex} must be a valid index of a Transaction in the list.
+     */
+    public void setTransaction(Index txnIndex, Transaction editedTransaction) {
+        requireAllNonNull(txnIndex, editedTransaction);
+
+        internalList.set(txnIndex.getZeroBased(), editedTransaction);
     }
 
     /**
@@ -61,6 +68,13 @@ public class TransactionList implements Iterable<Transaction> {
             // TODO handle transactions not found
             throw new TransactionNotFoundException();
         }
+    }
+
+    /**
+     * Returns the current number of transactions in the list.
+     */
+    public int getTransactionsCount() {
+        return internalList.size();
     }
 
     /**


### PR DESCRIPTION
- Add a few convenience methods inside Account
- Change implementation to use transaction index rather than transaction itself, since transaction is immutable, and is replaced when edited. (Fixes previous pull request of NPE if multiple rules activate)
- closes #46 