### PR TITLE
Fixes for PE bugs involving loans

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -296,7 +296,7 @@ Splits a joint payment equally among group members, then displays a list of who 
 Format: `loan split p/<person> x/<amount paid> ... [me/<your name> w/<date> d/<description>]`
 ****
 * Each `<person>` corresponds to an `<amount paid>`, representing how much the `person` paid for the group initially. +
-The order of all `person`s should match the order of `amount paid`.
+The order of each `person` should match the order of their `amount paid`.
 * Adding the optional `me/` will add all debts from the resulting list to your loan list.
 +
 `<your name>` must match one of the persons among the other `p/<person>` names.

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -219,6 +219,8 @@ Format: `loan list [out|in|unpaid|paid ...] [p/<person> ...] [x/<amount> ...] [w
 ****
 * Filter loans using one or more of the `out`, `in`, `unpaid`, `paid` filters.
 * Filter loans persons, amounts, dates and descriptions by adding one or more of the `p/<person>`, `x/<amount>`, `w/<date>`, `d/<description>` filters.
+* If more than one filter is used, filters will be joined using logical `AND`.
+For example, `loan list out p/Duke` will result in the filter: `loans out AND loans with Duke`.
 * Sort loans by date, amount, or persons' names using `s/w`, `s/x`, or `s/p` respectively.
 ** Sorting the list using the same method when it is already sorted will reverse the order of sorting (e.g. descending to ascending).
 ****

--- a/src/main/java/budgetbuddy/commons/util/StringUtil.java
+++ b/src/main/java/budgetbuddy/commons/util/StringUtil.java
@@ -66,17 +66,17 @@ public class StringUtil {
     }
 
     /**
-     * Returns true if {@code s} represents a non-negative unsigned long
+     * Returns true if {@code s} represents a positive unsigned long
      * e.g. 1, 2.2, 3, ..., {@code Long.MAX_VALUE} <br>
      * Will return false for any other non-null string input
      * e.g. empty string, "-1", "0", "+1", and " 2 " (untrimmed), "3 0" (contains whitespace), "1 a" (contains letters)
      * @throws NullPointerException if {@code s} is null.
      */
-    public static boolean isNonNegativeUnsignedLong(String s) {
+    public static boolean isPositiveUnsignedLong(String s) {
         requireNonNull(s);
         try {
             long value = Long.parseLong(s);
-            return value >= 0 && !s.startsWith("+");
+            return value > 0 && !s.startsWith("+");
         } catch (NumberFormatException nfe) {
             return false;
         }

--- a/src/main/java/budgetbuddy/logic/commands/loancommands/LoanListCommand.java
+++ b/src/main/java/budgetbuddy/logic/commands/loancommands/LoanListCommand.java
@@ -80,7 +80,7 @@ public class LoanListCommand extends Command {
             resultMessage += " " + MESSAGE_SORTED;
         }
 
-        model.getLoansManager().updateFilteredList(filters.stream().reduce(Predicate::or).orElse(FILTER_ALL));
+        model.getLoansManager().updateFilteredList(filters.stream().reduce(Predicate::and).orElse(FILTER_ALL));
         if (!filters.isEmpty()) {
             resultMessage += " " + MESSAGE_FILTERED;
         }

--- a/src/main/java/budgetbuddy/logic/commands/loancommands/LoanSplitCommand.java
+++ b/src/main/java/budgetbuddy/logic/commands/loancommands/LoanSplitCommand.java
@@ -62,7 +62,6 @@ public class LoanSplitCommand extends Command {
 
     public static final String MESSAGE_PERSON_AMOUNT_NUMBERS_MISMATCH =
             "The number of persons does not match the number of payments.";
-    public static final String MESSAGE_DUPLICATE_PERSONS = "Names of persons entered must be unique.";
 
     public static final String MESSAGE_INVALID_TOTAL = "Total amount must be more than zero.";
     public static final String MESSAGE_ALREADY_SPLIT_EQUALLY = "The amounts have already been split equally.";
@@ -96,8 +95,6 @@ public class LoanSplitCommand extends Command {
 
         if (persons.size() != amounts.size()) {
             throw new CommandException(MESSAGE_PERSON_AMOUNT_NUMBERS_MISMATCH);
-        } else if (hasDuplicates(persons)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSONS);
         }
 
         Person user = new Person(new Name("You"));

--- a/src/main/java/budgetbuddy/logic/commands/loancommands/LoanSplitCommand.java
+++ b/src/main/java/budgetbuddy/logic/commands/loancommands/LoanSplitCommand.java
@@ -1,7 +1,6 @@
 package budgetbuddy.logic.commands.loancommands;
 
 import static budgetbuddy.commons.util.CollectionUtil.generateCombinations;
-import static budgetbuddy.commons.util.CollectionUtil.hasDuplicates;
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_DATE;

--- a/src/main/java/budgetbuddy/logic/parser/CommandParserUtil.java
+++ b/src/main/java/budgetbuddy/logic/parser/CommandParserUtil.java
@@ -95,7 +95,7 @@ public class CommandParserUtil {
         }
 
         Long parsedDollars;
-        if (StringUtil.isNonNegativeUnsignedLong(dollarCentArray[0])) {
+        if (StringUtil.isPositiveUnsignedLong(dollarCentArray[0])) {
             parsedDollars = Long.parseLong(dollarCentArray[0]) * 100L;
         } else {
             throw new ParseException(Amount.MESSAGE_CONSTRAINTS);
@@ -104,7 +104,7 @@ public class CommandParserUtil {
         Long parsedCents = 0L;
         if (dollarCentArray.length == 2) {
             if (dollarCentArray[1].length() <= 2
-                    && StringUtil.isNonNegativeUnsignedLong(dollarCentArray[1])) {
+                    && StringUtil.isPositiveUnsignedLong(dollarCentArray[1])) {
                 parsedCents = dollarCentArray[1].length() == 1
                         ? Long.parseLong(dollarCentArray[1] + "0")
                         : Long.parseLong(dollarCentArray[1]);

--- a/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanCommandParser.java
+++ b/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanCommandParser.java
@@ -1,6 +1,7 @@
 package budgetbuddy.logic.parser.commandparsers.loancommandparsers;
 
 import static budgetbuddy.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static budgetbuddy.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_DATE;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
@@ -45,9 +46,11 @@ public class LoanCommandParser implements CommandParser<LoanCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_PERSON, PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE);
 
         String directionString = argMultimap.getPreamble().toUpperCase();
-        if (!arePrefixesPresent(argMultimap, PREFIX_PERSON, PREFIX_AMOUNT)
-                || !(directionString.equals(Direction.IN.toString())
-                || directionString.equals(Direction.OUT.toString()))) {
+        if (!(directionString.equals(Direction.IN.toString()) || directionString.equals(Direction.OUT.toString()))) {
+            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+        }
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_PERSON, PREFIX_AMOUNT)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LoanCommand.MESSAGE_USAGE));
         }
 
@@ -58,10 +61,8 @@ public class LoanCommandParser implements CommandParser<LoanCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LoanCommand.MESSAGE_USAGE));
         }
 
-        Name name = CommandParserUtil.parseName(argMultimap.getValue(PREFIX_PERSON).get());
-        Person person = new Person(name);
-
         Direction direction = Direction.valueOf(directionString.toUpperCase());
+        Person person = new Person(CommandParserUtil.parseName(argMultimap.getValue(PREFIX_PERSON).get()));
         Amount amount = CommandParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
 
         Optional<String> optionalDescription = argMultimap.getValue(PREFIX_DESCRIPTION);

--- a/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanCommandParser.java
+++ b/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanCommandParser.java
@@ -72,12 +72,7 @@ public class LoanCommandParser implements CommandParser<LoanCommand> {
         Optional<String> optionalDate = argMultimap.getValue(PREFIX_DATE);
         Date date = new Date();
         if (optionalDate.isPresent()) {
-            try {
-                date = CommandParserUtil.parseDate(optionalDate.get());
-            } catch (ParseException e) {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, LoanCommand.MESSAGE_USAGE));
-            }
+            date = CommandParserUtil.parseDate(optionalDate.get());
         }
 
         Status status = Status.UNPAID;

--- a/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanCommandParser.java
+++ b/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanCommandParser.java
@@ -20,7 +20,6 @@ import budgetbuddy.logic.parser.Prefix;
 import budgetbuddy.logic.parser.exceptions.ParseException;
 import budgetbuddy.model.attributes.Description;
 import budgetbuddy.model.attributes.Direction;
-import budgetbuddy.model.attributes.Name;
 import budgetbuddy.model.loan.Loan;
 import budgetbuddy.model.loan.Status;
 import budgetbuddy.model.person.Person;

--- a/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanSplitCommandParser.java
+++ b/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanSplitCommandParser.java
@@ -20,7 +20,6 @@ import budgetbuddy.logic.parser.CommandParser;
 import budgetbuddy.logic.parser.CommandParserUtil;
 import budgetbuddy.logic.parser.exceptions.ParseException;
 import budgetbuddy.model.attributes.Description;
-import budgetbuddy.model.attributes.Name;
 import budgetbuddy.model.person.Person;
 import budgetbuddy.model.transaction.Amount;
 
@@ -29,7 +28,7 @@ import budgetbuddy.model.transaction.Amount;
  */
 public class LoanSplitCommandParser implements CommandParser<LoanSplitCommand> {
 
-    public final String MESSAGE_DUPLICATE_PERSONS = "Duplicate persons found in the list of persons. "
+    public static final String MESSAGE_DUPLICATE_PERSONS = "Duplicate persons found in the list of persons. "
             + "Takes note that the list is case insensitive.";
 
     @Override

--- a/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanSplitCommandParser.java
+++ b/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanSplitCommandParser.java
@@ -20,6 +20,7 @@ import budgetbuddy.logic.parser.CommandParser;
 import budgetbuddy.logic.parser.CommandParserUtil;
 import budgetbuddy.logic.parser.exceptions.ParseException;
 import budgetbuddy.model.attributes.Description;
+import budgetbuddy.model.attributes.Name;
 import budgetbuddy.model.person.Person;
 import budgetbuddy.model.transaction.Amount;
 
@@ -27,6 +28,10 @@ import budgetbuddy.model.transaction.Amount;
  * Parses input arguments and creates a new LoanSplitCommand object.
  */
 public class LoanSplitCommandParser implements CommandParser<LoanSplitCommand> {
+
+    public final String MESSAGE_DUPLICATE_PERSONS = "Duplicate persons found in the list of persons. "
+            + "Takes note that the list is case insensitive.";
+
     @Override
     public String name() {
         return LoanSplitCommand.COMMAND_WORD;
@@ -72,8 +77,16 @@ public class LoanSplitCommandParser implements CommandParser<LoanSplitCommand> {
         List<Person> persons = new ArrayList<Person>();
         List<Amount> amounts = new ArrayList<Amount>();
 
-        for (String personName : argMultiMap.getAllValues(PREFIX_PERSON)) {
-            persons.add(new Person(CommandParserUtil.parseName(personName)));
+        List<String> personNames = argMultiMap.getAllValues(PREFIX_PERSON);
+        for (int i = 0; i < personNames.size(); i++) {
+            String currPersonName = personNames.get(i);
+            // check for persons with the same name (case-insensitive)
+            for (int j = i + 1; j < personNames.size(); j++) {
+                if (currPersonName.equalsIgnoreCase(personNames.get(j))) {
+                    throw new ParseException(MESSAGE_DUPLICATE_PERSONS);
+                }
+            }
+            persons.add(new Person(CommandParserUtil.parseName(currPersonName)));
         }
 
         for (String amountStr : argMultiMap.getAllValues(PREFIX_AMOUNT)) {

--- a/src/main/java/budgetbuddy/model/transaction/Amount.java
+++ b/src/main/java/budgetbuddy/model/transaction/Amount.java
@@ -12,7 +12,7 @@ public class Amount {
     public static final String MAX_AMOUNT = "9999999999999999";
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Amounts should be non-negative numbers, should not be blank, "
+            "Amounts should be positive numbers, should not be blank, "
                     + "and should not exceed " + CURRENCY_SIGN + MAX_AMOUNT + ".";
     public static final String MESSAGE_CENTS_PARSE_ERROR =
             "Cents should be at most two decimal places long.";

--- a/src/main/resources/view/LoanCard.fxml
+++ b/src/main/resources/view/LoanCard.fxml
@@ -9,33 +9,33 @@
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <GridPane HBox.hgrow="ALWAYS">
         <columnConstraints>
-            <ColumnConstraints percentWidth="5"/>
+            <ColumnConstraints percentWidth="10"/>
         </columnConstraints>
         <columnConstraints>
-            <ColumnConstraints percentWidth="70" />
+            <ColumnConstraints percentWidth="10"/>
         </columnConstraints>
         <columnConstraints>
-            <ColumnConstraints percentWidth="25"/>
+            <ColumnConstraints percentWidth="80" />
         </columnConstraints>
-        <VBox alignment="CENTER" minHeight="105" GridPane.columnIndex="0">
+        <VBox alignment="CENTER_RIGHT" minHeight="105" GridPane.columnIndex="0">
+            <padding>
+                <Insets top="5" right="5" bottom="5" left="15" />
+            </padding>
+            <Label fx:id="status" styleClass="cell_big_label"/>
+        </VBox>
+        <VBox alignment="CENTER" minHeight="105" GridPane.columnIndex="1">
             <padding>
                 <Insets top="5" right="5" bottom="5" left="15"/>
             </padding>
             <Label fx:id="id" styleClass="cell_big_label"/>
         </VBox>
-        <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="1">
+        <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="2">
             <padding>
                 <Insets top="5" right="5" bottom="5" left="15" />
             </padding>
             <Label fx:id="amountDirectionPerson" text="\$first" styleClass="cell_big_label" />
             <Label fx:id="date" styleClass="cell_small_label" text="\$date" />
             <Label fx:id="description" styleClass="cell_small_label" text="\$description" prefWidth="400" />
-        </VBox>
-        <VBox alignment="CENTER" minHeight="105" GridPane.columnIndex="2">
-            <padding>
-                <Insets top="5" right="5" bottom="5" left="15" />
-            </padding>
-            <Label fx:id="status" styleClass="cell_big_label"/>
         </VBox>
     </GridPane>
 </HBox>


### PR DESCRIPTION
- Fix loan delete message when non-existent person(s) targeted, fixes #121 
- Change loan list filtering to combine filters with logical `AND` instead of `OR`, fixes #124 
- Change position of loan status icon, fixes #132 
- Fix markdown in user guide, fixes #133 
- Change error message for invalid date when adding a loan, fixes #137 
- Tweak error message for invalid loan commands to `Unknown command`, instead of printing syntax for adding a loan; fixes #138 
- Change `Amount` constraint to be positive instead of non-negative, fixes #141 
- Change check for duplicate names in `loan split` to be case-insensitive, fixes #151 