### PR TITLE
Make rules more powerful

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -365,11 +365,12 @@ Refer to <<Scripting>> for script usage.
 *** `inamt` : Transaction amount inwards
 *** `outamt` : Transaction amount outwards
 *** `desc` : Transaction description
+*** `date` : Transaction date
 ** A predicate operator can be one of the following:
-*** `=` : equality operator
-*** `<` , `\<=`  , `>=` , `>` : inequality operators
-*** `contains` : string comparison operator
-** A value can be a number or a string of length not more than 180 characters.
+*** `=` : Equality comparison operator
+*** `<` , `\<=`  , `>=` , `>` : Inequality comparison operators
+*** `contains` : Substring check operator (Cannot be used on dates)
+** A value can be a number or a string of length not more than 180 characters
 It can contain the following special characters: _!#$%&'*+=?`[{|}]~^.-_
 
 * **Action**: In the order of `<action operator> <value>`

--- a/src/main/java/budgetbuddy/commons/util/AppUtil.java
+++ b/src/main/java/budgetbuddy/commons/util/AppUtil.java
@@ -2,7 +2,7 @@ package budgetbuddy.commons.util;
 
 import static java.util.Objects.requireNonNull;
 
-import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 
 import budgetbuddy.MainApp;
 import javafx.scene.image.Image;
@@ -11,11 +11,8 @@ import javafx.scene.image.Image;
  * A container for App specific utility functions
  */
 public class AppUtil {
-    private static final ThreadLocal<SimpleDateFormat> dateFormat = ThreadLocal.withInitial(() -> {
-        SimpleDateFormat format = new SimpleDateFormat("d/M/yy");
-        format.setLenient(false);
-        return format;
-    });
+    private static final DateTimeFormatter dateFormatter =
+            DateTimeFormatter.ofPattern("d/M/yy");
 
     public static Image getImage(String imagePath) {
         requireNonNull(imagePath);
@@ -23,11 +20,11 @@ public class AppUtil {
     }
 
     /**
-     * Returns a {@code SimpleDateFormat} for use in displaying/parsing dates.
+     * Returns a {@code DateTimeFormatter} for use in displaying/parsing dates.
      * The primary purpose of this method is to standardise date display across the app.
      */
-    public static SimpleDateFormat getDateFormat() {
-        return dateFormat.get();
+    public static DateTimeFormatter getDateFormatter() {
+        return dateFormatter;
     }
 
     /**

--- a/src/main/java/budgetbuddy/logic/commands/loancommands/LoanEditCommand.java
+++ b/src/main/java/budgetbuddy/logic/commands/loancommands/LoanEditCommand.java
@@ -6,7 +6,7 @@ import static budgetbuddy.logic.parser.CliSyntax.PREFIX_DATE;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_PERSON;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.Optional;
 
 import budgetbuddy.commons.core.index.Index;
@@ -84,7 +84,7 @@ public class LoanEditCommand extends Command {
         Person updatedPerson = loanEditDescriptor.getPerson().orElse(loanToEdit.getPerson());
         Direction updatedDirection = loanEditDescriptor.getDirection().orElse(loanToEdit.getDirection());
         Amount updatedAmount = loanEditDescriptor.getAmount().orElse(loanToEdit.getAmount());
-        Date updatedDate = loanEditDescriptor.getDate().orElse(loanToEdit.getDate());
+        LocalDate updatedDate = loanEditDescriptor.getDate().orElse(loanToEdit.getDate());
         Description updatedDescription = loanEditDescriptor.getDescription().orElse(loanToEdit.getDescription());
         Status updatedStatus = loanEditDescriptor.getStatus().orElse(loanToEdit.getStatus());
 
@@ -115,7 +115,7 @@ public class LoanEditCommand extends Command {
         private Person person;
         private Direction direction;
         private Amount amount;
-        private Date date;
+        private LocalDate date;
         private Description description;
         private Status status;
 
@@ -161,11 +161,11 @@ public class LoanEditCommand extends Command {
             return Optional.ofNullable(amount);
         }
 
-        public void setDate(Date date) {
+        public void setDate(LocalDate date) {
             this.date = date;
         }
 
-        public Optional<Date> getDate() {
+        public Optional<LocalDate> getDate() {
             return Optional.ofNullable(date);
         }
 

--- a/src/main/java/budgetbuddy/logic/commands/loancommands/LoanSplitCommand.java
+++ b/src/main/java/budgetbuddy/logic/commands/loancommands/LoanSplitCommand.java
@@ -10,9 +10,9 @@ import static budgetbuddy.logic.parser.CliSyntax.PREFIX_PERSON;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_USER;
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -79,12 +79,12 @@ public class LoanSplitCommand extends Command {
 
     private Optional<Person> optionalUser;
     private Optional<Description> optionalDescription;
-    private Optional<Date> optionalDate;
+    private Optional<LocalDate> optionalDate;
 
     public LoanSplitCommand(List<Person> persons, List<Amount> amounts, List<Long> maxShares,
                             Optional<Person> optionalUser,
                             Optional<Description> optionalDescription,
-                            Optional<Date> optionalDate) throws CommandException {
+                            Optional<LocalDate> optionalDate) throws CommandException {
         requireAllNonNull(persons, amounts, optionalUser, optionalDescription, optionalDate);
 
         if (persons.size() != amounts.size()) {
@@ -247,12 +247,12 @@ public class LoanSplitCommand extends Command {
             if (debtorCreditorAmount.debtor.equals(user)) {
                 userLoans.add(new Loan(
                         debtorCreditorAmount.creditor, Direction.IN, debtorCreditorAmount.amount,
-                        optionalDate.orElse(new Date()), optionalDescription.orElse(new Description("")),
+                        optionalDate.orElse(LocalDate.now()), optionalDescription.orElse(new Description("")),
                         Status.UNPAID));
             } else if (debtorCreditorAmount.creditor.equals(user)) {
                 userLoans.add(new Loan(
                         debtorCreditorAmount.debtor, Direction.OUT, debtorCreditorAmount.amount,
-                        optionalDate.orElse(new Date()), optionalDescription.orElse(new Description("")),
+                        optionalDate.orElse(LocalDate.now()), optionalDescription.orElse(new Description("")),
                         Status.UNPAID));
             }
         });

--- a/src/main/java/budgetbuddy/logic/commands/transactioncommands/TransactionEditCommand.java
+++ b/src/main/java/budgetbuddy/logic/commands/transactioncommands/TransactionEditCommand.java
@@ -11,7 +11,7 @@ import static budgetbuddy.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_DIRECTION;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_RECURRENCE;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -142,7 +142,7 @@ public class TransactionEditCommand extends ScriptCommand {
                                           Account targetAccount,
                                           Account updatedAccount) throws CommandException {
 
-        Date updatedDate = transactionEditDescriptor.getDate().isPresent()
+        LocalDate updatedDate = transactionEditDescriptor.getDate().isPresent()
                 ? transactionEditDescriptor.getDate().get()
                 : targetTransaction.getDate();
 
@@ -182,7 +182,7 @@ public class TransactionEditCommand extends ScriptCommand {
         private Amount amount;
         private Description description;
         private Set<Category> categories = new HashSet<>();
-        private Date date;
+        private LocalDate date;
 
         public TransactionEditDescriptor() {}
 
@@ -194,11 +194,11 @@ public class TransactionEditCommand extends ScriptCommand {
             this.categories = toCopy.categories;
         }
 
-        public Optional<Date> getDate() {
+        public Optional<LocalDate> getDate() {
             return Optional.ofNullable(date);
         }
 
-        public void setDate(Date date) {
+        public void setDate(LocalDate date) {
             this.date = date;
         }
 

--- a/src/main/java/budgetbuddy/logic/parser/CommandParserUtil.java
+++ b/src/main/java/budgetbuddy/logic/parser/CommandParserUtil.java
@@ -1,9 +1,10 @@
 package budgetbuddy.logic.parser;
 
-import static budgetbuddy.commons.util.AppUtil.getDateFormat;
+import static budgetbuddy.commons.util.AppUtil.getDateFormatter;
 import static java.util.Objects.requireNonNull;
 
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.util.regex.Matcher;
 
 import budgetbuddy.commons.core.index.Index;
@@ -133,15 +134,15 @@ public class CommandParserUtil {
 
 
     /**
-     * Parses a {@code String date} into a {@code Date}.
+     * Parses a {@code String date} into a {@code LocalDate}.
      * Leading and trailing whitespaces will be trimmed.
      */
-    public static Date parseDate(String date) throws ParseException {
+    public static LocalDate parseDate(String date) throws ParseException {
         requireNonNull(date);
         String trimmedDate = date.trim();
         try {
-            return getDateFormat().parse(trimmedDate);
-        } catch (java.text.ParseException e) {
+            return LocalDate.parse(trimmedDate, getDateFormatter());
+        } catch (DateTimeParseException e) {
             throw new ParseException(e.getMessage());
         }
     }

--- a/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanCommandParser.java
+++ b/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanCommandParser.java
@@ -7,7 +7,7 @@ import static budgetbuddy.logic.parser.CliSyntax.PREFIX_DATE;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_PERSON;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -73,7 +73,7 @@ public class LoanCommandParser implements CommandParser<LoanCommand> {
                 : new Description("");
 
         Optional<String> optionalDate = argMultimap.getValue(PREFIX_DATE);
-        Date date = new Date();
+        LocalDate date = LocalDate.now();
         if (optionalDate.isPresent()) {
             date = CommandParserUtil.parseDate(optionalDate.get());
         }

--- a/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanSplitCommandParser.java
+++ b/src/main/java/budgetbuddy/logic/parser/commandparsers/loancommandparsers/LoanSplitCommandParser.java
@@ -9,8 +9,8 @@ import static budgetbuddy.logic.parser.CliSyntax.PREFIX_MAX_SHARE;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_PERSON;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_USER;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -43,7 +43,7 @@ public class LoanSplitCommandParser implements CommandParser<LoanSplitCommand> {
 
     private Optional<Person> optionalUser;
     private Optional<Description> optionalDescription;
-    private Optional<Date> optionalDate;
+    private Optional<LocalDate> optionalDate;
 
     @Override
     public String name() {

--- a/src/main/java/budgetbuddy/logic/parser/commandparsers/transactioncommandparsers/TransactionAddCommandParser.java
+++ b/src/main/java/budgetbuddy/logic/parser/commandparsers/transactioncommandparsers/TransactionAddCommandParser.java
@@ -8,9 +8,9 @@ import static budgetbuddy.logic.parser.CliSyntax.PREFIX_DATE;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_DIRECTION;
 
+import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.List;
-import java.time.LocalDate;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;

--- a/src/main/java/budgetbuddy/logic/parser/commandparsers/transactioncommandparsers/TransactionAddCommandParser.java
+++ b/src/main/java/budgetbuddy/logic/parser/commandparsers/transactioncommandparsers/TransactionAddCommandParser.java
@@ -8,9 +8,9 @@ import static budgetbuddy.logic.parser.CliSyntax.PREFIX_DATE;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_DIRECTION;
 
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -74,13 +74,13 @@ public class TransactionAddCommandParser implements CommandParser<TransactionAdd
             categoriesSet.add(CommandParserUtil.parseCategory(c));
         }
 
-        /**
+        /*
          * Return current date when optionalDate is not present
          */
         Optional<String> optionalDate = argMultiMap.getValue(PREFIX_DATE);
-        Date date = optionalDate.isPresent()
+        LocalDate date = optionalDate.isPresent()
                 ? CommandParserUtil.parseDate(optionalDate.get())
-                : new Date();
+                : LocalDate.now();
 
         Transaction transaction = new Transaction(date, amount, direction, description, categoriesSet);
 

--- a/src/main/java/budgetbuddy/logic/parser/commandparsers/viewcommandparsers/ViewFilterCommandParser.java
+++ b/src/main/java/budgetbuddy/logic/parser/commandparsers/viewcommandparsers/ViewFilterCommandParser.java
@@ -5,7 +5,7 @@ import static budgetbuddy.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_FROM;
 import static budgetbuddy.logic.parser.CliSyntax.PREFIX_UNTIL;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.Optional;
 
 import budgetbuddy.logic.commands.view.ViewFilterCommand;
@@ -47,13 +47,13 @@ public class ViewFilterCommandParser implements CommandParser<ViewFilterCommand>
                         : Optional.empty();
 
         Optional<String> optionalFromString = argMultimap.getValue(PREFIX_FROM);
-        Optional<Date> optionalFrom =
+        Optional<LocalDate> optionalFrom =
                 argMultimap.getValue(PREFIX_FROM).isPresent()
                         ? Optional.of(CommandParserUtil.parseDate(optionalFromString.get()))
                         : Optional.empty();
 
         Optional<String> optionalUntilString = argMultimap.getValue(PREFIX_UNTIL);
-        Optional<Date> optionalUntil =
+        Optional<LocalDate> optionalUntil =
                 argMultimap.getValue(PREFIX_UNTIL).isPresent()
                         ? Optional.of(CommandParserUtil.parseDate(optionalUntilString.get()))
                         : Optional.empty();

--- a/src/main/java/budgetbuddy/logic/rules/RuleEngine.java
+++ b/src/main/java/budgetbuddy/logic/rules/RuleEngine.java
@@ -154,45 +154,27 @@ public class RuleEngine {
     }
 
     /**
-     * Returns if a value can be parsed into the specified type.
+     * Converts a Value into the specified type.
+     *
+     * @throws ParseException if the value cannot be parsed.
      */
-    public static boolean isValueParsable(String typeName, Value value) {
+    public static Object convertValue(String typeName, Value value) throws ParseException {
         requireAllNonNull(typeName, value);
         switch (typeName) {
         case TYPE_CATEGORY:
-            try {
-                CommandParserUtil.parseCategory(value.toString());
-                break;
-            } catch (ParseException e) {
-                return false;
-            }
+            return CommandParserUtil.parseCategory(value.toString());
         case TYPE_DESC:
-            try {
-                CommandParserUtil.parseDescription(value.toString());
-                break;
-            } catch (ParseException e) {
-                return false;
-            }
+            return CommandParserUtil.parseDescription(value.toString());
         case TYPE_AMOUNT:
-            try {
-                CommandParserUtil.parseAmount(value.toString());
-                break;
-            } catch (ParseException e) {
-                return false;
-            }
+            return CommandParserUtil.parseAmount(value.toString());
         case TYPE_DATE:
-            // todo: need to try parsing date
-            return false;
+            return CommandParserUtil.parseDate(value.toString());
         case TYPE_BLANK:
-            if (value.toString().isEmpty()) {
-                break;
-            }
-            return false;
+            return null;
         default:
-            return false;
+            assert false : "Invalid type";
+            throw new ParseException("Invalid type");
         }
-
-        return true;
     }
 
     /**
@@ -205,17 +187,22 @@ public class RuleEngine {
         case DESCRIPTION:
             return txn.getDescription();
         case IN_AMOUNT:
-            return (txn.getDirection().equals(Direction.IN) ? 1 : -1)
-                    * (txn.getAmount().toLong() / 100.0);
+            if (txn.getDirection().equals(Direction.IN)) {
+                return txn.getAmount();
+            }
+            break;
         case OUT_AMOUNT:
-            return (txn.getDirection().equals(Direction.OUT) ? 1 : -1)
-                    * (txn.getAmount().toLong() / 100.0);
+            if (txn.getDirection().equals(Direction.OUT)) {
+                return txn.getAmount();
+            }
+            break;
         case DATE:
             return txn.getDate();
         default:
             // impossible
             assert false : "Unhandled attribute";
-            return null;
+            break;
         }
+        return null;
     }
 }

--- a/src/main/java/budgetbuddy/logic/rules/testable/ContainsExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/testable/ContainsExpression.java
@@ -25,7 +25,12 @@ public class ContainsExpression extends TestableExpression {
     @Override
     public boolean test(Index txnIndex, Account account) {
         requireAllNonNull(txnIndex, account);
-        String left = RuleEngine.extractAttribute(attribute, txnIndex, account).toString();
+        Object attr = RuleEngine.extractAttribute(attribute, txnIndex, account);
+        if (attr == null) {
+            return false;
+        }
+
+        String left = attr.toString();
         String right = value.toString();
         return left.contains(right);
     }

--- a/src/main/java/budgetbuddy/logic/rules/testable/EqualToExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/testable/EqualToExpression.java
@@ -3,6 +3,7 @@ package budgetbuddy.logic.rules.testable;
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
 import budgetbuddy.commons.core.index.Index;
+import budgetbuddy.logic.parser.exceptions.ParseException;
 import budgetbuddy.logic.rules.RuleEngine;
 import budgetbuddy.model.account.Account;
 import budgetbuddy.model.rule.expression.Attribute;
@@ -23,10 +24,20 @@ public class EqualToExpression extends TestableExpression {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public boolean test(Index txnIndex, Account account) {
         requireAllNonNull(txnIndex, account);
-        double left = (double) RuleEngine.extractAttribute(attribute, txnIndex, account);
-        double right = Double.parseDouble(value.toString());
-        return left == right;
+        Comparable left = (Comparable) RuleEngine.extractAttribute(attribute, txnIndex, account);
+        Comparable right;
+        try {
+            right = (Comparable) RuleEngine.convertValue(attribute.getEvaluatedType(), value);
+
+            // attributes should never have a blank type
+            assert right != null;
+        } catch (ParseException e) {
+            return false;
+        }
+
+        return left != null && left.compareTo(right) == 0;
     }
 }

--- a/src/main/java/budgetbuddy/logic/rules/testable/LessEqualExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/testable/LessEqualExpression.java
@@ -3,6 +3,7 @@ package budgetbuddy.logic.rules.testable;
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
 import budgetbuddy.commons.core.index.Index;
+import budgetbuddy.logic.parser.exceptions.ParseException;
 import budgetbuddy.logic.rules.RuleEngine;
 import budgetbuddy.model.account.Account;
 import budgetbuddy.model.rule.expression.Attribute;
@@ -23,10 +24,20 @@ public class LessEqualExpression extends TestableExpression {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public boolean test(Index txnIndex, Account account) {
         requireAllNonNull(txnIndex, account);
-        double left = (double) RuleEngine.extractAttribute(attribute, txnIndex, account);
-        double right = Double.parseDouble(value.toString());
-        return left >= 0 && left <= right;
+        Comparable left = (Comparable) RuleEngine.extractAttribute(attribute, txnIndex, account);
+        Comparable right;
+        try {
+            right = (Comparable) RuleEngine.convertValue(attribute.getEvaluatedType(), value);
+
+            // attributes should never have a blank type
+            assert right != null;
+        } catch (ParseException e) {
+            return false;
+        }
+
+        return left != null && left.compareTo(right) <= 0;
     }
 }

--- a/src/main/java/budgetbuddy/logic/rules/testable/LessThanExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/testable/LessThanExpression.java
@@ -3,6 +3,7 @@ package budgetbuddy.logic.rules.testable;
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
 import budgetbuddy.commons.core.index.Index;
+import budgetbuddy.logic.parser.exceptions.ParseException;
 import budgetbuddy.logic.rules.RuleEngine;
 import budgetbuddy.model.account.Account;
 import budgetbuddy.model.rule.expression.Attribute;
@@ -23,10 +24,20 @@ public class LessThanExpression extends TestableExpression {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public boolean test(Index txnIndex, Account account) {
         requireAllNonNull(txnIndex, account);
-        double left = (double) RuleEngine.extractAttribute(attribute, txnIndex, account);
-        double right = Double.parseDouble(value.toString());
-        return left >= 0 && left < right;
+        Comparable left = (Comparable) RuleEngine.extractAttribute(attribute, txnIndex, account);
+        Comparable right;
+        try {
+            right = (Comparable) RuleEngine.convertValue(attribute.getEvaluatedType(), value);
+
+            // attributes should never have a blank type
+            assert right != null;
+        } catch (ParseException e) {
+            return false;
+        }
+
+        return left != null && left.compareTo(right) < 0;
     }
 }

--- a/src/main/java/budgetbuddy/logic/rules/testable/MoreEqualExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/testable/MoreEqualExpression.java
@@ -3,6 +3,7 @@ package budgetbuddy.logic.rules.testable;
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
 import budgetbuddy.commons.core.index.Index;
+import budgetbuddy.logic.parser.exceptions.ParseException;
 import budgetbuddy.logic.rules.RuleEngine;
 import budgetbuddy.model.account.Account;
 import budgetbuddy.model.rule.expression.Attribute;
@@ -23,10 +24,20 @@ public class MoreEqualExpression extends TestableExpression {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public boolean test(Index txnIndex, Account account) {
         requireAllNonNull(txnIndex, account);
-        double left = (double) RuleEngine.extractAttribute(attribute, txnIndex, account);
-        double right = Double.parseDouble(value.toString());
-        return left >= 0 && left >= right;
+        Comparable left = (Comparable) RuleEngine.extractAttribute(attribute, txnIndex, account);
+        Comparable right;
+        try {
+            right = (Comparable) RuleEngine.convertValue(attribute.getEvaluatedType(), value);
+
+            // attributes should never have a blank type
+            assert right != null;
+        } catch (ParseException e) {
+            return false;
+        }
+
+        return left != null && left.compareTo(right) >= 0;
     }
 }

--- a/src/main/java/budgetbuddy/logic/rules/testable/MoreThanExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/testable/MoreThanExpression.java
@@ -3,6 +3,7 @@ package budgetbuddy.logic.rules.testable;
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
 import budgetbuddy.commons.core.index.Index;
+import budgetbuddy.logic.parser.exceptions.ParseException;
 import budgetbuddy.logic.rules.RuleEngine;
 import budgetbuddy.model.account.Account;
 import budgetbuddy.model.rule.expression.Attribute;
@@ -23,10 +24,20 @@ public class MoreThanExpression extends TestableExpression {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public boolean test(Index txnIndex, Account account) {
         requireAllNonNull(txnIndex, account);
-        double left = (double) RuleEngine.extractAttribute(attribute, txnIndex, account);
-        double right = Double.parseDouble(value.toString());
-        return left >= 0 && left > right;
+        Comparable left = (Comparable) RuleEngine.extractAttribute(attribute, txnIndex, account);
+        Comparable right;
+        try {
+            right = (Comparable) RuleEngine.convertValue(attribute.getEvaluatedType(), value);
+
+            // attributes should never have a blank type
+            assert right != null;
+        } catch (ParseException e) {
+            return false;
+        }
+
+        return left != null && left.compareTo(right) > 0;
     }
 }

--- a/src/main/java/budgetbuddy/logic/rules/testable/TestableExpression.java
+++ b/src/main/java/budgetbuddy/logic/rules/testable/TestableExpression.java
@@ -19,6 +19,7 @@ public abstract class TestableExpression implements Testable {
 
     /**
      * Constructs a TestableExpression given an attribute and a value.
+     * The attribute and value must be able to evaluate to the same type.
      *
      * @param attribute the attribute to be tested with.
      * @param value the value to be tested against.

--- a/src/main/java/budgetbuddy/model/attributes/Description.java
+++ b/src/main/java/budgetbuddy/model/attributes/Description.java
@@ -6,7 +6,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * A stub class to represent a description of an entity.
  */
-public class Description {
+public class Description implements Comparable<Description> {
 
     public static final int MAX_LENGTH = 180;
 
@@ -31,6 +31,11 @@ public class Description {
 
     public String getDescription() {
         return description;
+    }
+
+    @Override
+    public int compareTo(Description other) {
+        return description.compareTo(other.description);
     }
 
     @Override

--- a/src/main/java/budgetbuddy/model/loan/Loan.java
+++ b/src/main/java/budgetbuddy/model/loan/Loan.java
@@ -1,9 +1,9 @@
 package budgetbuddy.model.loan;
 
-import static budgetbuddy.commons.util.AppUtil.getDateFormat;
+import static budgetbuddy.commons.util.AppUtil.getDateFormatter;
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.Objects;
 
 import budgetbuddy.model.attributes.Description;
@@ -22,7 +22,7 @@ public class Loan {
     private final Person person;
     private final Direction direction;
     private final Amount amount;
-    private final Date date;
+    private final LocalDate date;
     private final Description description;
     private final Status status;
 
@@ -30,7 +30,7 @@ public class Loan {
      * Every field must be present and not null.
      */
     public Loan(Person person, Direction direction, Amount amount,
-                Date date, Description description, Status status) {
+                LocalDate date, Description description, Status status) {
         requireAllNonNull(person, direction, amount, date, description, status);
         this.person = person;
         this.direction = direction;
@@ -52,12 +52,12 @@ public class Loan {
         return amount;
     }
 
-    public Date getDate() {
+    public LocalDate getDate() {
         return date;
     }
 
     public String getDateString() {
-        return getDateFormat().format(date);
+        return getDateFormatter().format(date);
     }
 
     public Description getDescription() {

--- a/src/main/java/budgetbuddy/model/loan/predicates/DateMatchPredicate.java
+++ b/src/main/java/budgetbuddy/model/loan/predicates/DateMatchPredicate.java
@@ -2,7 +2,7 @@ package budgetbuddy.model.loan.predicates;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.function.Predicate;
 
 import budgetbuddy.model.loan.Loan;
@@ -11,9 +11,9 @@ import budgetbuddy.model.loan.Loan;
  * A predicate to check equality between a given date and the date of a given loan.
  */
 public class DateMatchPredicate implements Predicate<Loan> {
-    private final Date date;
+    private final LocalDate date;
 
-    public DateMatchPredicate(Date date) {
+    public DateMatchPredicate(LocalDate date) {
         requireNonNull(date);
         this.date = date;
     }

--- a/src/main/java/budgetbuddy/model/rule/expression/ActionExpression.java
+++ b/src/main/java/budgetbuddy/model/rule/expression/ActionExpression.java
@@ -1,11 +1,12 @@
 package budgetbuddy.model.rule.expression;
 
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
-import static budgetbuddy.logic.rules.RuleEngine.isValueParsable;
+import static budgetbuddy.logic.rules.RuleEngine.convertValue;
 
 import java.util.Objects;
 import java.util.regex.Pattern;
 
+import budgetbuddy.logic.parser.exceptions.ParseException;
 import budgetbuddy.model.rule.Rule;
 import budgetbuddy.model.rule.RuleAction;
 
@@ -22,8 +23,8 @@ public class ActionExpression extends RuleAction {
 
     public static final String MESSAGE_TYPE_REQUIREMENTS =
             "The operator and value of the expression have to evaluate to the correct type:\n"
-            + "e.g. setcategory food, where 'setcategory' expects a string\n"
-            + "and 'food' is a string";
+            + "e.g. set_cat Food, where 'set_cat' expects a string\n"
+            + "and 'Food' is a string";
 
     public static final Pattern FORMAT_REGEX =
             Pattern.compile("^(?<exprOperator>\\S+)\\s*(?<exprValue>.*)$");
@@ -57,7 +58,14 @@ public class ActionExpression extends RuleAction {
      */
     public static boolean isValidActionExpr(Operator operator, Value value) {
         return operator.getExpectedTypes().stream()
-                .anyMatch(type -> isValueParsable(type, value));
+                .anyMatch(type -> {
+                    try {
+                        convertValue(type, value);
+                        return true;
+                    } catch (ParseException e) {
+                        return false;
+                    }
+                });
     }
 
     @Override

--- a/src/main/java/budgetbuddy/model/rule/expression/Attribute.java
+++ b/src/main/java/budgetbuddy/model/rule/expression/Attribute.java
@@ -1,18 +1,20 @@
 package budgetbuddy.model.rule.expression;
 
-import java.util.Arrays;
+import static budgetbuddy.logic.rules.RuleEngine.TYPE_AMOUNT;
+import static budgetbuddy.logic.rules.RuleEngine.TYPE_DATE;
+import static budgetbuddy.logic.rules.RuleEngine.TYPE_DESC;
 
-import budgetbuddy.logic.rules.RuleEngine;
+import java.util.Arrays;
 
 /**
  * Represents a Attribute in an PredicateExpression
  * Guarantees: immutable; is valid as declared in {@link #isValidAttribute(String)}
  */
 public enum Attribute {
-    DESCRIPTION("desc", RuleEngine.TYPE_CATEGORY),
-    OUT_AMOUNT("outamt", RuleEngine.TYPE_AMOUNT),
-    IN_AMOUNT("inamt", RuleEngine.TYPE_AMOUNT),
-    DATE("date", RuleEngine.TYPE_DATE);
+    DESCRIPTION("desc", TYPE_DESC),
+    OUT_AMOUNT("outamt", TYPE_AMOUNT),
+    IN_AMOUNT("inamt", TYPE_AMOUNT),
+    DATE("date", TYPE_DATE);
 
     public static final String MESSAGE_CONSTRAINTS =
             "Attributes should be valid and not be blank\n"

--- a/src/main/java/budgetbuddy/model/rule/expression/Operator.java
+++ b/src/main/java/budgetbuddy/model/rule/expression/Operator.java
@@ -1,11 +1,15 @@
 package budgetbuddy.model.rule.expression;
 
+import static budgetbuddy.logic.rules.RuleEngine.TYPE_AMOUNT;
+import static budgetbuddy.logic.rules.RuleEngine.TYPE_BLANK;
+import static budgetbuddy.logic.rules.RuleEngine.TYPE_CATEGORY;
+import static budgetbuddy.logic.rules.RuleEngine.TYPE_DATE;
+import static budgetbuddy.logic.rules.RuleEngine.TYPE_DESC;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-
-import budgetbuddy.logic.rules.RuleEngine;
 
 /**
  * Represents an Operator in an expression.
@@ -13,22 +17,22 @@ import budgetbuddy.logic.rules.RuleEngine;
  */
 public enum Operator {
     // Predicate operators
-    LESS_THAN("<", "<", RuleEngine.TYPE_AMOUNT),
-    MORE_THAN(">", ">", RuleEngine.TYPE_AMOUNT),
-    LESS_EQUAL("<=", "<=", RuleEngine.TYPE_AMOUNT),
-    MORE_EQUAL(">=", ">=", RuleEngine.TYPE_AMOUNT),
-    EQUAL_TO("=", "=", RuleEngine.TYPE_AMOUNT),
-    CONTAINS("contains", "contains", RuleEngine.TYPE_CATEGORY),
+    LESS_THAN("<", "<", TYPE_DESC, TYPE_DATE, TYPE_AMOUNT),
+    MORE_THAN(">", ">", TYPE_DESC, TYPE_DATE, TYPE_AMOUNT),
+    LESS_EQUAL("<=", "<=", TYPE_DESC, TYPE_DATE, TYPE_AMOUNT),
+    MORE_EQUAL(">=", ">=", TYPE_DESC, TYPE_DATE, TYPE_AMOUNT),
+    EQUAL_TO("=", "=", TYPE_DESC, TYPE_DATE, TYPE_AMOUNT),
+    CONTAINS("contains", "contains", TYPE_DESC, TYPE_AMOUNT),
 
     // Action operators
-    SET_CATEGORY("set_cat", "set category", RuleEngine.TYPE_CATEGORY),
-    REMOVE_CATEGORY("remove_cat", "remove category", RuleEngine.TYPE_CATEGORY),
-    SET_DESC("set_desc", "set description", RuleEngine.TYPE_CATEGORY),
-    APPEND_DESC("app_desc", "append desc", RuleEngine.TYPE_DESC),
-    PREPEND_DESC("prep_desc", "prepend desc", RuleEngine.TYPE_DESC),
-    SET_IN("set_in", "set txn inwards", RuleEngine.TYPE_BLANK),
-    SET_OUT("set_out", "set txn outwards", RuleEngine.TYPE_BLANK),
-    SWITCH_DIRECTION("switch_direct", "switch txn direction", RuleEngine.TYPE_BLANK);
+    SET_CATEGORY("set_cat", "set category", TYPE_CATEGORY),
+    REMOVE_CATEGORY("remove_cat", "remove category", TYPE_CATEGORY),
+    SET_DESC("set_desc", "set description", TYPE_DESC),
+    APPEND_DESC("app_desc", "append desc", TYPE_DESC),
+    PREPEND_DESC("prep_desc", "prepend desc", TYPE_DESC),
+    SET_IN("set_in", "set txn inwards", TYPE_BLANK),
+    SET_OUT("set_out", "set txn outwards", TYPE_BLANK),
+    SWITCH_DIRECTION("switch_direct", "switch txn direction", TYPE_BLANK);
 
     public static final String MESSAGE_CONSTRAINTS =
             "Operators should be valid for their expression and not be blank\n"

--- a/src/main/java/budgetbuddy/model/transaction/Amount.java
+++ b/src/main/java/budgetbuddy/model/transaction/Amount.java
@@ -6,7 +6,7 @@ import budgetbuddy.commons.util.AppUtil;
  * Represents the Amount in a Transaction.
  * Guarantees: immutable, is valid as declared in {@link #isValidAmount(long)}
  */
-public class Amount {
+public class Amount implements Comparable<Amount> {
 
     public static final String CURRENCY_SIGN = "$";
     public static final String MAX_AMOUNT = "9999999999999999";
@@ -40,6 +40,11 @@ public class Amount {
      */
     public static boolean isValidAmount(long test) {
         return test >= 0;
+    }
+
+    @Override
+    public int compareTo(Amount other) {
+        return Long.compare(amount, other.amount);
     }
 
     @Override

--- a/src/main/java/budgetbuddy/model/transaction/Transaction.java
+++ b/src/main/java/budgetbuddy/model/transaction/Transaction.java
@@ -2,8 +2,8 @@ package budgetbuddy.model.transaction;
 
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.time.LocalDate;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -22,12 +22,12 @@ public class Transaction {
     private Amount amount;
     private Description description;
     private Set<Category> categories = new HashSet<>();
-    private Date date;
+    private LocalDate date;
 
     /**
      * Every field must be present and not null.
      */
-    public Transaction(Date date, Amount amount, Direction direction, Description description,
+    public Transaction(LocalDate date, Amount amount, Direction direction, Description description,
                        Category... categories) {
         requireAllNonNull(date, amount, direction);
         this.direction = direction;
@@ -43,7 +43,7 @@ public class Transaction {
     /**
      * Constructor that allows categories to be entered as a @code{@literal Set<Category>}
      */
-    public Transaction(Date date, Amount amount, Direction direction, Description description,
+    public Transaction(LocalDate date, Amount amount, Direction direction, Description description,
                        Set<Category> categories) {
         requireAllNonNull(date, amount, direction);
         this.direction = direction;
@@ -69,7 +69,7 @@ public class Transaction {
         return categories;
     }
 
-    public Date getDate() {
+    public LocalDate getDate() {
         return date;
     }
 

--- a/src/main/java/budgetbuddy/model/transaction/TransactionMatchesConditionsPredicate.java
+++ b/src/main/java/budgetbuddy/model/transaction/TransactionMatchesConditionsPredicate.java
@@ -1,6 +1,6 @@
 package budgetbuddy.model.transaction;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -11,12 +11,12 @@ import budgetbuddy.model.attributes.Category;
  */
 public class TransactionMatchesConditionsPredicate implements Predicate<Transaction> {
     private final Optional<Category> categoryOptional;
-    private final Optional<Date> fromOptional;
-    private final Optional<Date> untilOptional;
+    private final Optional<LocalDate> fromOptional;
+    private final Optional<LocalDate> untilOptional;
 
     public TransactionMatchesConditionsPredicate(Optional<Category> categoryOptional,
-                                                 Optional<Date> fromOptional,
-                                                 Optional<Date> untilOptional) {
+                                                 Optional<LocalDate> fromOptional,
+                                                 Optional<LocalDate> untilOptional) {
         this.categoryOptional = categoryOptional;
         this.fromOptional = fromOptional;
         this.untilOptional = untilOptional;
@@ -30,12 +30,12 @@ public class TransactionMatchesConditionsPredicate implements Predicate<Transact
             }
         }
         if (fromOptional.isPresent()) {
-            if (!transaction.getDate().after(fromOptional.get())) {
+            if (!transaction.getDate().isAfter(fromOptional.get())) {
                 return false;
             }
         }
         if (untilOptional.isPresent()) {
-            if (!transaction.getDate().before(fromOptional.get())) {
+            if (!transaction.getDate().isBefore(fromOptional.get())) {
                 return false;
             }
         }

--- a/src/main/java/budgetbuddy/model/util/SampleDataUtil.java
+++ b/src/main/java/budgetbuddy/model/util/SampleDataUtil.java
@@ -1,7 +1,7 @@
 package budgetbuddy.model.util;
 
+import java.time.LocalDate;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 
 import budgetbuddy.model.LoansManager;
@@ -21,10 +21,10 @@ public class SampleDataUtil {
     public static List<Loan> getSampleLoans() {
         return Arrays.asList(
                 new Loan(new Person(new Name("Example Person 1")),
-                        Direction.OUT, new Amount(420), new Date(),
+                        Direction.OUT, new Amount(420), LocalDate.now(),
                         new Description("Paid for their stuff."), Status.UNPAID),
                 new Loan(new Person(new Name("Example Person 2")),
-                        Direction.IN, new Amount(10000), new Date(),
+                        Direction.IN, new Amount(10000), LocalDate.now(),
                         new Description("Owe them for that party."), Status.UNPAID));
     }
 

--- a/src/main/java/budgetbuddy/storage/loans/JsonAdaptedLoan.java
+++ b/src/main/java/budgetbuddy/storage/loans/JsonAdaptedLoan.java
@@ -1,10 +1,10 @@
 package budgetbuddy.storage.loans;
 
-import static budgetbuddy.commons.util.AppUtil.getDateFormat;
+import static budgetbuddy.commons.util.AppUtil.getDateFormatter;
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.text.ParseException;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -28,7 +28,7 @@ public class JsonAdaptedLoan {
     private final String personName;
     private final String direction;
     private final long amount;
-    private final Date date;
+    private final String date;
     private final String description;
     private final String status;
 
@@ -39,7 +39,7 @@ public class JsonAdaptedLoan {
     public JsonAdaptedLoan(@JsonProperty("personName") String personName,
                            @JsonProperty("direction") String direction,
                            @JsonProperty("amount") long amount,
-                           @JsonProperty("date") Date date,
+                           @JsonProperty("date") String date,
                            @JsonProperty("description") String description,
                            @JsonProperty("status") String status) {
         requireAllNonNull(personName, direction, amount, date, description, status);
@@ -59,7 +59,7 @@ public class JsonAdaptedLoan {
         personName = source.getPerson().getName().toString();
         direction = source.getDirection().toString();
         amount = source.getAmount().toLong();
-        date = source.getDate();
+        date = getDateFormatter().format(source.getDate());
         description = source.getDescription().toString();
         status = source.getStatus().toString();
     }
@@ -119,18 +119,16 @@ public class JsonAdaptedLoan {
     }
 
     /**
-     * Validates the adapted date as a {@code java.util.Date} object.
+     * Validates the adapted date as a {@code LocalDate} object.
      * @return The validated date.
      * @throws IllegalValueException If validation fails.
      */
-    private Date getValidatedDate() throws IllegalValueException {
+    private LocalDate getValidatedDate() throws IllegalValueException {
         try {
-            String dateStr = getDateFormat().format(date);
-            getDateFormat().parse(dateStr);
-        } catch (ParseException e) {
+            return LocalDate.parse(date, getDateFormatter());
+        } catch (DateTimeParseException e) {
             throw new IllegalValueException("Error reading stored date.");
         }
-        return date;
     }
 
     /**

--- a/src/test/java/budgetbuddy/logic/rules/RuleEngineTest.java
+++ b/src/test/java/budgetbuddy/logic/rules/RuleEngineTest.java
@@ -3,18 +3,18 @@ package budgetbuddy.logic.rules;
 import static budgetbuddy.logic.rules.RuleEngine.TYPE_AMOUNT;
 import static budgetbuddy.logic.rules.RuleEngine.TYPE_BLANK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.HashSet;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import budgetbuddy.commons.core.index.Index;
+import budgetbuddy.logic.parser.exceptions.ParseException;
 import budgetbuddy.logic.rules.performable.Performable;
 import budgetbuddy.logic.rules.testable.ContainsExpression;
 import budgetbuddy.logic.rules.testable.Testable;
@@ -164,13 +164,13 @@ class RuleEngineTest {
     }
 
     @Test
-    void isValueParsable_parsableValue_returnsTrue() {
-        assertTrue(RuleEngine.isValueParsable(TYPE_AMOUNT, new Value("200")));
+    void convertValue_parsableValue() throws ParseException {
+        assertEquals(new Amount(20000), RuleEngine.convertValue(TYPE_AMOUNT, new Value("200")));
     }
 
     @Test
-    void isValueParsable_notParsableValue_returnsFalse() {
-        assertFalse(RuleEngine.isValueParsable(TYPE_BLANK, new Value("200")));
+    void convertValue_blankValue() throws ParseException {
+        assertEquals(null, RuleEngine.convertValue(TYPE_BLANK, new Value("200")));
     }
 
     @Test
@@ -189,7 +189,7 @@ class RuleEngineTest {
         account.addTransaction(txn);
         Index txnIndex = TypicalIndexes.INDEX_FIRST_ITEM;
 
-        assertEquals(-100.00, RuleEngine.extractAttribute(Attribute.IN_AMOUNT, txnIndex, account));
+        assertEquals(null, RuleEngine.extractAttribute(Attribute.IN_AMOUNT, txnIndex, account));
     }
 
     @Test
@@ -198,7 +198,7 @@ class RuleEngineTest {
         account.addTransaction(txn);
         Index txnIndex = TypicalIndexes.INDEX_FIRST_ITEM;
 
-        assertEquals(100.00, RuleEngine.extractAttribute(Attribute.OUT_AMOUNT, txnIndex, account));
+        assertEquals(new Amount(10000), RuleEngine.extractAttribute(Attribute.OUT_AMOUNT, txnIndex, account));
     }
 
     /**
@@ -217,7 +217,7 @@ class RuleEngineTest {
     public class TransactionStub extends Transaction {
 
         public TransactionStub(String desc) {
-            super(new Date(), new Amount(10000), Direction.OUT, new Description(desc), new HashSet<>());
+            super(LocalDate.now(), new Amount(10000), Direction.OUT, new Description(desc), new HashSet<>());
         }
     }
 }

--- a/src/test/java/budgetbuddy/model/LoansManagerTest.java
+++ b/src/test/java/budgetbuddy/model/LoansManagerTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
@@ -92,9 +92,9 @@ public class LoansManagerTest {
         // sort by date, newest first
         loansManager.sortLoans(LoanSorters.DATE_NEWEST);
         assertTrue(IntStream.range(0, loansManager.getFilteredLoans().size() - 1).allMatch(i -> {
-            Date first = loansManager.getFilteredLoans().get(i).getDate();
-            Date second = loansManager.getFilteredLoans().get(i + 1).getDate();
-            return first.after(second) || first.equals(second);
+            LocalDate first = loansManager.getFilteredLoans().get(i).getDate();
+            LocalDate second = loansManager.getFilteredLoans().get(i + 1).getDate();
+            return first.isAfter(second) || first.isEqual(second);
         }));
 
         // sort by persons' names in alphabetical order
@@ -117,9 +117,9 @@ public class LoansManagerTest {
         loansManager.sortLoans(LoanSorters.DATE_NEWEST);
         loansManager.sortLoans(LoanSorters.DATE_NEWEST);
         assertTrue(IntStream.range(0, loansManager.getFilteredLoans().size() - 1).allMatch(i -> {
-            Date first = loansManager.getFilteredLoans().get(i).getDate();
-            Date second = loansManager.getFilteredLoans().get(i + 1).getDate();
-            return first.before(second) || first.equals(second);
+            LocalDate first = loansManager.getFilteredLoans().get(i).getDate();
+            LocalDate second = loansManager.getFilteredLoans().get(i + 1).getDate();
+            return first.isBefore(second) || first.isEqual(second);
         }));
 
         // sort by persons' names in reverse alphabetical order

--- a/src/test/java/budgetbuddy/model/loan/LoanSortersTest.java
+++ b/src/test/java/budgetbuddy/model/loan/LoanSortersTest.java
@@ -26,7 +26,7 @@ public class LoanSortersTest {
     public void dateNewestSorter_sortList_loansSortedByNewestDateFirst() {
         loans.sort(LoanSorters.DATE_NEWEST);
         assertTrue(IntStream.range(0, loans.size() - 1)
-                .allMatch(i -> loans.get(i).getDate().after(loans.get(i + 1).getDate())
+                .allMatch(i -> loans.get(i).getDate().isAfter(loans.get(i + 1).getDate())
                         || loans.get(i).getDate().equals(loans.get(i + 1).getDate())));
     }
 

--- a/src/test/java/budgetbuddy/model/loan/LoanTest.java
+++ b/src/test/java/budgetbuddy/model/loan/LoanTest.java
@@ -4,7 +4,7 @@ import static budgetbuddy.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
 
@@ -81,7 +81,8 @@ public class LoanTest {
         assertNotEquals(TypicalLoans.JOHN_OUT_UNPAID, editedJohnOutUnpaid);
 
         // different date -> returns false
-        editedJohnOutUnpaid = new LoanBuilder(TypicalLoans.JOHN_OUT_UNPAID).withDate(new Date(100000L)).build();
+        editedJohnOutUnpaid = new LoanBuilder(TypicalLoans.JOHN_OUT_UNPAID)
+                .withDate(LocalDate.ofEpochDay(10)).build();
         assertNotEquals(TypicalLoans.JOHN_OUT_UNPAID, editedJohnOutUnpaid);
     }
 }

--- a/src/test/java/budgetbuddy/testutil/loanutil/LoanBuilder.java
+++ b/src/test/java/budgetbuddy/testutil/loanutil/LoanBuilder.java
@@ -1,6 +1,6 @@
 package budgetbuddy.testutil.loanutil;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 import budgetbuddy.model.attributes.Description;
 import budgetbuddy.model.attributes.Direction;
@@ -19,14 +19,14 @@ public class LoanBuilder {
     public static final Direction DEFAULT_DIRECTION = Direction.OUT;
     public static final Amount DEFAULT_AMOUNT = new Amount(100L);
     public static final Description DEFAULT_DESCRIPTION = new Description("The description.");
-    public static final Date DEFAULT_DATE = new Date();
+    public static final LocalDate DEFAULT_DATE = LocalDate.now();
     public static final Status DEFAULT_STATUS = Status.UNPAID;
 
     private Person person;
     private Direction direction;
     private Amount amount;
     private Description description;
-    private Date date;
+    private LocalDate date;
     private Status status;
 
     public LoanBuilder() {
@@ -80,9 +80,9 @@ public class LoanBuilder {
     }
 
     /**
-     * Sets the {@code Date} of the {@code Loan} that we are building.
+     * Sets the {@code LocalDate} of the {@code Loan} that we are building.
      */
-    public LoanBuilder withDate(Date date) {
+    public LoanBuilder withDate(LocalDate date) {
         this.date = date;
         return this;
     }

--- a/src/test/java/budgetbuddy/testutil/loanutil/TypicalLoans.java
+++ b/src/test/java/budgetbuddy/testutil/loanutil/TypicalLoans.java
@@ -1,6 +1,6 @@
 package budgetbuddy.testutil.loanutil;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 
 import budgetbuddy.model.loan.Loan;
@@ -11,17 +11,17 @@ import budgetbuddy.model.loan.Loan;
 public class TypicalLoans {
 
     public static final Loan JOHN_OUT_UNPAID = new LoanBuilder().withPerson("John").withDirection("OUT")
-            .withAmount(10000L).withDescription("For dinner.").withDate(new Date(1)).withStatus("UNPAID")
+            .withAmount(10000L).withDescription("For dinner.").withDate(LocalDate.ofEpochDay(1)).withStatus("UNPAID")
             .build();
     public static final Loan PETER_OUT_PAID = new LoanBuilder().withPerson("Peter").withDirection("OUT")
-            .withAmount(4000L).withDescription("For lunch.").withDate(new Date(2)).withStatus("PAID")
+            .withAmount(4000L).withDescription("For lunch.").withDate(LocalDate.ofEpochDay(2)).withStatus("PAID")
             .build();
     public static final Loan MARY_IN_UNPAID = new LoanBuilder().withPerson("Mary").withDirection("IN")
-            .withAmount(420L).withDescription("For supper.").withDate(new Date(3)).withStatus("UNPAID")
+            .withAmount(420L).withDescription("For supper.").withDate(LocalDate.ofEpochDay(3)).withStatus("UNPAID")
             .build();
     public static final Loan ZED_OUT_PAID = new LoanBuilder().withPerson("Zed").withDirection("IN")
-            .withAmount(66666L).withDescription("For the midnight snack.").withDate(new Date(4)).withStatus("PAID")
-            .build();
+            .withAmount(66666L).withDescription("For the midnight snack.").withDate(LocalDate.ofEpochDay(4))
+            .withStatus("PAID").build();
 
     public static final List<Loan> LOAN_LIST =
             List.of(JOHN_OUT_UNPAID, MARY_IN_UNPAID, PETER_OUT_PAID, ZED_OUT_PAID);


### PR DESCRIPTION
- Dates are now valid attributes
- Dates, descriptions and amounts can all be compared using the comparison operators
- LocalDate is used instead of Date to remove irrelevant time/timezone information.