### PR TITLE
Add coveralls badge to README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,6 +2,7 @@
 ifdef::env-github,env-browser[:relfileprefix: docs/]
 
 https://travis-ci.org/AY1920S1-CS2103T-W13-4/main[image:https://travis-ci.org/AY1920S1-CS2103T-W13-4/main.svg?branch=master[Build Status]]
+https://coveralls.io/github/AY1920S1-CS2103T-W13-4/main?branch=master[image:https://coveralls.io/repos/github/AY1920S1-CS2103T-W13-4/main/badge.svg?branch=master[Coverage Status]]
 
 ifdef::env-github[]
 image::docs/images/Ui.png[width="600"]


### PR DESCRIPTION
Just so that we can see the coverage on the main page.