### PR TITLE
Fixes for loans

### DIFF
--- a/src/main/java/budgetbuddy/logic/commands/loancommands/LoanCommand.java
+++ b/src/main/java/budgetbuddy/logic/commands/loancommands/LoanCommand.java
@@ -13,6 +13,7 @@ import budgetbuddy.logic.commands.CommandResult;
 import budgetbuddy.logic.commands.exceptions.CommandException;
 import budgetbuddy.model.Model;
 import budgetbuddy.model.loan.Loan;
+import budgetbuddy.model.loan.exceptions.DuplicateLoanException;
 
 /**
  * Adds a loan.
@@ -37,6 +38,9 @@ public class LoanCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New loan added:\n%1$s";
 
+    public static final String MESSAGE_DUPLICATE_LOAN = "An identical loan already exists in the list.\n"
+            + "Perhaps try changing the field(s) of the new loan to separate it from the existing one.";
+
     private final Loan toAdd;
 
     public LoanCommand(Loan loan) {
@@ -48,7 +52,11 @@ public class LoanCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireAllNonNull(model, model.getLoansManager());
 
-        model.getLoansManager().addLoan(toAdd);
+        try {
+            model.getLoansManager().addLoan(toAdd);
+        } catch (DuplicateLoanException e) {
+            throw new CommandException(MESSAGE_DUPLICATE_LOAN);
+        }
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), CommandCategory.LOAN);
     }
 

--- a/src/main/java/budgetbuddy/logic/commands/loancommands/LoanDeleteCommand.java
+++ b/src/main/java/budgetbuddy/logic/commands/loancommands/LoanDeleteCommand.java
@@ -2,7 +2,6 @@ package budgetbuddy.logic.commands.loancommands;
 
 import static budgetbuddy.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -12,7 +11,6 @@ import budgetbuddy.logic.commands.CommandResult;
 import budgetbuddy.logic.commands.exceptions.CommandException;
 import budgetbuddy.model.LoansManager;
 import budgetbuddy.model.Model;
-import budgetbuddy.model.loan.exceptions.LoanNotFoundException;
 import budgetbuddy.model.person.Person;
 
 /**
@@ -43,31 +41,10 @@ public class LoanDeleteCommand extends MultiLoanCommand {
         List<Index> targetLoanIndices = constructTargetLoanIndicesList(loansManager);
         Consumer<Index> deleteLoanOp = loansManager::deleteLoan;
 
-        actOnTargetLoans(targetLoanIndices, deleteLoanOp);
+        actOnTargetLoans(loansManager, targetLoanIndices, deleteLoanOp);
 
         String resultMessage = constructMultiLoanResult(MESSAGE_SUCCESS);
         return new CommandResult(resultMessage, CommandCategory.LOAN);
-    }
-
-    /**
-     * The indices of loans in the list will (potentially) change after each deletion.
-     * This version of multi-loan targeting takes this into account
-     * when passing the target indices to the given operation.
-     */
-    @Override
-    public void actOnTargetLoans(List<Index> targetLoanIndices, Consumer<Index> operation) {
-        int indicesProcessed = 0;
-        // indices MUST be sorted before iteration
-        targetLoanIndices.sort(Comparator.comparingInt(Index::getZeroBased));
-        for (Index index : targetLoanIndices) {
-            try {
-                operation.accept(Index.fromZeroBased(index.getZeroBased() - indicesProcessed));
-                indicesProcessed++;
-                hitLoanIndices.add(index);
-            } catch (LoanNotFoundException e) {
-                missingLoanIndices.add(index);
-            }
-        }
     }
 
     @Override

--- a/src/main/java/budgetbuddy/logic/commands/loancommands/LoanEditCommand.java
+++ b/src/main/java/budgetbuddy/logic/commands/loancommands/LoanEditCommand.java
@@ -21,6 +21,7 @@ import budgetbuddy.model.attributes.Description;
 import budgetbuddy.model.attributes.Direction;
 import budgetbuddy.model.loan.Loan;
 import budgetbuddy.model.loan.Status;
+import budgetbuddy.model.loan.exceptions.DuplicateLoanException;
 import budgetbuddy.model.loan.exceptions.LoanNotFoundException;
 import budgetbuddy.model.person.Person;
 import budgetbuddy.model.transaction.Amount;
@@ -44,7 +45,8 @@ public class LoanEditCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Loan %1$d edited.";
     public static final String MESSAGE_UNEDITED = "At least one field must be provided for editing.";
-    public static final String MESSAGE_FAILURE = "The loan targeted for editing could not be found.";
+    public static final String MESSAGE_LOAN_NOT_FOUND = "The loan targeted for editing could not be found.";
+    public static final String MESSAGE_DUPLICATE_LOAN = "The edited loan already exists in the list.";
 
     private final Index targetLoanIndex;
     private final LoanEditDescriptor loanEditDescriptor;
@@ -71,7 +73,9 @@ public class LoanEditCommand extends Command {
             editedLoan = createEditedLoan(targetLoan, loanEditDescriptor);
             loansManager.editLoan(targetLoanIndex, editedLoan);
         } catch (LoanNotFoundException e) {
-            throw new CommandException(MESSAGE_FAILURE);
+            throw new CommandException(MESSAGE_LOAN_NOT_FOUND);
+        } catch (DuplicateLoanException e) {
+            throw new CommandException(MESSAGE_DUPLICATE_LOAN);
         }
 
         return new CommandResult(

--- a/src/main/java/budgetbuddy/logic/commands/loancommands/UpdateStatusCommand.java
+++ b/src/main/java/budgetbuddy/logic/commands/loancommands/UpdateStatusCommand.java
@@ -30,10 +30,10 @@ public abstract class UpdateStatusCommand extends MultiLoanCommand {
         List<Index> targetLoanIndices = constructTargetLoanIndicesList(loansManager);
         Consumer<Index> updateStatusOp = targetIndex -> {
             Loan updatedLoan = createUpdatedLoan(loansManager.getLoan(targetIndex), updatedStatus);
-            loansManager.editLoan(targetIndex, updatedLoan);
+            loansManager.updateStatus(targetIndex, updatedLoan);
         };
 
-        actOnTargetLoans(targetLoanIndices, updateStatusOp);
+        actOnTargetLoans(loansManager, targetLoanIndices, updateStatusOp);
     }
 
     /**

--- a/src/main/java/budgetbuddy/model/loan/Loan.java
+++ b/src/main/java/budgetbuddy/model/loan/Loan.java
@@ -86,6 +86,18 @@ public class Loan {
     }
 
     /**
+     * Returns true if all fields (EXCEPT status) of a given loan are identical to this one.
+     * @param loan The loan to check.
+     */
+    public boolean isSameLoan(Loan loan) {
+        return getPerson().equals(loan.getPerson())
+                && getDirection().equals(loan.getDirection())
+                && getAmount().equals(loan.getAmount())
+                && getDate().equals(loan.getDate())
+                && getDescription().equals(loan.getDescription());
+    }
+
+    /**
      * Checks all fields of a Loan for equality (person, direction, amount, date, description, status).
      */
     @Override
@@ -98,13 +110,13 @@ public class Loan {
             return false;
         }
 
-        // do not compare status of loan
         Loan otherLoan = (Loan) other;
         return otherLoan.getPerson().isSamePerson(person)
                 && otherLoan.getDirection() == direction
                 && otherLoan.getAmount().equals(amount)
                 && otherLoan.getDate().equals(date)
-                && otherLoan.getDescription().equals(description);
+                && otherLoan.getDescription().equals(description)
+                && otherLoan.getStatus().equals(status);
     }
 
     @Override

--- a/src/main/java/budgetbuddy/model/loan/exceptions/DuplicateLoanException.java
+++ b/src/main/java/budgetbuddy/model/loan/exceptions/DuplicateLoanException.java
@@ -1,0 +1,6 @@
+package budgetbuddy.model.loan.exceptions;
+
+/**
+ * Signals that an identical loan (except for status) already exists in the list.
+ */
+public class DuplicateLoanException extends RuntimeException {}

--- a/src/test/java/budgetbuddy/model/LoansManagerTest.java
+++ b/src/test/java/budgetbuddy/model/LoansManagerTest.java
@@ -150,7 +150,7 @@ public class LoansManagerTest {
     public void addLoan_addAfterFilter_filteredLoansShowsAllLoan() {
         int targetSize = loansManager.getLoansCount();
         loansManager.updateFilteredList(LoanFilters.getStatusPredicate(Status.PAID));
-        loansManager.addLoan(TypicalLoans.JOHN_OUT_UNPAID);
+        loansManager.addLoan(new LoanBuilder().build());
         assertEquals(targetSize + 1, loansManager.getFilteredLoans().size());
     }
 

--- a/src/test/java/budgetbuddy/model/LoansManagerTest.java
+++ b/src/test/java/budgetbuddy/model/LoansManagerTest.java
@@ -17,6 +17,7 @@ import budgetbuddy.model.loan.Loan;
 import budgetbuddy.model.loan.LoanFilters;
 import budgetbuddy.model.loan.LoanSorters;
 import budgetbuddy.model.loan.Status;
+import budgetbuddy.model.loan.exceptions.DuplicateLoanException;
 import budgetbuddy.model.loan.exceptions.LoanNotFoundException;
 import budgetbuddy.model.loan.predicates.AmountMatchPredicate;
 import budgetbuddy.model.loan.predicates.DateMatchPredicate;
@@ -155,6 +156,11 @@ public class LoansManagerTest {
     }
 
     @Test
+    public void addLoan_duplicateLoan_throwsDuplicateLoanException() {
+        assertThrows(DuplicateLoanException.class, () -> loansManager.addLoan(TypicalLoans.JOHN_OUT_UNPAID));
+    }
+
+    @Test
     public void editLoan_validIndexValidLoan_editedLoanReplacesTargetLoan() {
         Index targetIndex = TypicalIndexes.INDEX_FIRST_ITEM;
 
@@ -163,6 +169,23 @@ public class LoansManagerTest {
 
         loansManager.editLoan(targetIndex, editedLoan);
         assertEquals(editedLoan, loansManager.getLoan(targetIndex));
+    }
+
+    @Test
+    public void editLoan_duplicateLoan_throwsDuplicateLoanException() {
+        assertThrows(DuplicateLoanException.class, () -> loansManager.editLoan(
+                TypicalIndexes.INDEX_THIRD_ITEM, TypicalLoans.JOHN_OUT_UNPAID));
+    }
+
+    @Test
+    public void updateStatus_validIndexValidLoan_updatedLoanReplacesTargetLoan() {
+        Index targetIndex = TypicalIndexes.INDEX_FIRST_ITEM;
+
+        Loan targetLoan = loansManager.getLoan(targetIndex);
+        Loan updatedLoan = new LoanBuilder(targetLoan).withStatus("PAID").build();
+
+        loansManager.updateStatus(targetIndex, updatedLoan);
+        assertEquals(updatedLoan, loansManager.getLoan(targetIndex));
     }
 
     @Test

--- a/src/test/java/budgetbuddy/model/loan/LoanTest.java
+++ b/src/test/java/budgetbuddy/model/loan/LoanTest.java
@@ -2,7 +2,9 @@ package budgetbuddy.model.loan;
 
 import static budgetbuddy.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
 
@@ -42,6 +44,33 @@ public class LoanTest {
     public void isPaid() {
         assert !TypicalLoans.JOHN_OUT_UNPAID.isPaid();
         assert TypicalLoans.PETER_OUT_PAID.isPaid();
+    }
+
+    @Test
+    public void isSameLoan() {
+        Loan loan = TypicalLoans.JOHN_OUT_UNPAID;
+
+        // identical -> returns true
+        Loan loanCopy = new LoanBuilder(loan).build();
+        assertTrue(loan.isSameLoan(loanCopy));
+
+        // different status -> returns true
+        Loan loanWithDifferentStatus = new LoanBuilder(loan).withStatus("PAID").build();
+        assertTrue(loan.isSameLoan(loanWithDifferentStatus));
+
+        // other different properties -> returns false
+
+        Loan loanOther = new LoanBuilder(loan).withAmount(loan.getAmount().toLong() + 1L).build();
+        assertFalse(loan.isSameLoan(loanOther));
+
+        loanOther = new LoanBuilder(loan).withPerson("Mary").build();
+        assertFalse(loan.isSameLoan(loanOther));
+
+        loanOther = new LoanBuilder(loan).withDate(loan.getDate().minusDays(1)).build();
+        assertFalse(loan.isSameLoan(loanOther));
+
+        loanOther = new LoanBuilder(loan).withDescription("Bogus description").build();
+        assertFalse(loan.isSameLoan(loanOther));
     }
 
     @Test


### PR DESCRIPTION
- Match the internal targeting of loans (paid/unpaid/edit) to what the user sees when filtering the list
- Prevent duplicate loans from being created to avoid incorrect targeting of loans