### PR TITLE
Fix possible duplicate loan caused by loan split

### DIFF
--- a/src/test/java/budgetbuddy/logic/commands/loancommands/LoanSplitCommandTest.java
+++ b/src/test/java/budgetbuddy/logic/commands/loancommands/LoanSplitCommandTest.java
@@ -119,8 +119,9 @@ public class LoanSplitCommandTest {
                 getDefaultPersons(), getDefaultAmounts(), new ArrayList<>(),
                 Optional.of(TypicalPersons.ELLE), Optional.of(new Description("Test")), Optional.of(LocalDate.now()));
 
-        CommandResult expectedCommandResult =
-                new CommandResult(LoanSplitCommand.MESSAGE_SUCCESS_LOANS_ADDED, CommandCategory.LOAN_SPLIT);
+        CommandResult expectedCommandResult = new CommandResult(
+                LoanSplitCommand.MESSAGE_SUCCESS + " " + LoanSplitCommand.MESSAGE_LOANS_ADDED,
+                CommandCategory.LOAN_SPLIT);
         Model expectedModel = new ModelManager();
         expectedModel.getLoansManager().setDebtors(getDefaultDebtorsWithOptionalUser());
         expectedModel.getLoansManager().addLoan(getDefaultOptionalLoan());


### PR DESCRIPTION
- Loan split will no longer throw an uncaught exception if a loan it is trying to add already exists in the list. The user will see the list of loans that couldn't be added.